### PR TITLE
fix: bxl target patterns didn't accept multiple args

### DIFF
--- a/app/buck2_bxl/src/bxl/starlark_defs/cli_args.rs
+++ b/app/buck2_bxl/src/bxl/starlark_defs/cli_args.rs
@@ -600,9 +600,9 @@ impl CliArgType {
                         )
                     }))
             }
-            CliArgType::TargetExpr => clap.num_args(1),
-            CliArgType::ConfiguredTargetExpr => clap.num_args(1),
-            CliArgType::SubTargetExpr => clap.num_args(1),
+            CliArgType::TargetExpr => clap.num_args(1).action(ArgAction::Append),
+            CliArgType::ConfiguredTargetExpr => clap.num_args(1).action(ArgAction::Append),
+            CliArgType::SubTargetExpr => clap.num_args(1).action(ArgAction::Append),
             CliArgType::Json => clap.num_args(1),
             CliArgType::JsonFile => clap.num_args(1),
         }
@@ -737,20 +737,25 @@ impl CliArgType {
                     r.map(Some)
                 })?,
                 CliArgType::TargetExpr => {
-                    let x = clap.value_of().unwrap_or("");
-                    let pattern = ParsedPattern::<TargetPatternExtra>::parse_relaxed(
-                        &ctx.target_alias_resolver,
-                        ctx.relative_dir.as_cell_path(),
-                        x,
-                        &ctx.cell_resolver,
-                        &ctx.cell_alias_resolver,
-                    )?;
-                    let loaded = load_patterns(
-                        &mut ctx.dice.clone(),
-                        vec![pattern],
-                        MissingTargetBehavior::Fail,
-                    )
-                    .await?;
+                    let patterns = clap
+                        .values_of()
+                        .map(|xs| {
+                            xs.map(|x| {
+                                ParsedPattern::<TargetPatternExtra>::parse_relaxed(
+                                    &ctx.target_alias_resolver,
+                                    ctx.relative_dir.as_cell_path(),
+                                    x,
+                                    &ctx.cell_resolver,
+                                    &ctx.cell_alias_resolver,
+                                )
+                            })
+                            .collect::<buck2_error::Result<Vec<_>>>()
+                        })
+                        .unwrap_or(Ok(Vec::new()))?;
+
+                    let loaded =
+                        load_patterns(&mut ctx.dice.clone(), patterns, MissingTargetBehavior::Fail)
+                            .await?;
                     Some(CliArgValue::List(
                         loaded
                             .iter_loaded_targets()
@@ -759,18 +764,25 @@ impl CliArgType {
                     ))
                 }
                 CliArgType::ConfiguredTargetExpr => {
-                    let arg = clap.value_of().unwrap_or("");
-                    let pattern_with_modifiers =
-                        ParsedPatternWithModifiers::<TargetPatternExtra>::parse_relaxed(
-                            &ctx.target_alias_resolver,
-                            ctx.relative_dir.as_cell_path(),
-                            arg,
-                            &ctx.cell_resolver,
-                            &ctx.cell_alias_resolver,
-                        )?;
+                    let patterns = clap
+                        .values_of()
+                        .map(|xs| {
+                            xs.map(|x| {
+                                ParsedPatternWithModifiers::<TargetPatternExtra>::parse_relaxed(
+                                    &ctx.target_alias_resolver,
+                                    ctx.relative_dir.as_cell_path(),
+                                    x,
+                                    &ctx.cell_resolver,
+                                    &ctx.cell_alias_resolver,
+                                )
+                            })
+                            .collect::<buck2_error::Result<Vec<_>>>()
+                        })
+                        .unwrap_or(Ok(Vec::new()))?;
+
                     let result = load_compatible_patterns_with_modifiers(
                         &mut ctx.dice.clone(),
-                        vec![pattern_with_modifiers],
+                        patterns,
                         &ctx.global_cfg_options,
                         MissingTargetBehavior::Fail,
                         false,
@@ -785,20 +797,25 @@ impl CliArgType {
                     ))
                 }
                 CliArgType::SubTargetExpr => {
-                    let x = clap.value_of().unwrap_or("");
-                    let pattern = ParsedPattern::<ProvidersPatternExtra>::parse_relaxed(
-                        &ctx.target_alias_resolver,
-                        ctx.relative_dir.as_cell_path(),
-                        x,
-                        &ctx.cell_resolver,
-                        &ctx.cell_alias_resolver,
-                    )?;
-                    let loaded = load_patterns(
-                        &mut ctx.dice.clone(),
-                        vec![pattern],
-                        MissingTargetBehavior::Fail,
-                    )
-                    .await?;
+                    let patterns = clap
+                        .values_of()
+                        .map(|xs| {
+                            xs.map(|x| {
+                                ParsedPattern::<ProvidersPatternExtra>::parse_relaxed(
+                                    &ctx.target_alias_resolver,
+                                    ctx.relative_dir.as_cell_path(),
+                                    x,
+                                    &ctx.cell_resolver,
+                                    &ctx.cell_alias_resolver,
+                                )
+                            })
+                            .collect::<buck2_error::Result<Vec<_>>>()
+                        })
+                        .unwrap_or(Ok(Vec::new()))?;
+
+                    let loaded =
+                        load_patterns(&mut ctx.dice.clone(), patterns, MissingTargetBehavior::Fail)
+                            .await?;
 
                     Some(CliArgValue::List(
                         loaded

--- a/tests/core/bxl/test_cli.py
+++ b/tests/core/bxl/test_cli.py
@@ -36,10 +36,16 @@ async def test_bxl_cli(buck: Buck) -> None:
         "3",
         "--target",
         ":foo",
+        "--target",
+        ":bar",
         "--sub_target",
         "cell/pkg:bar[sub]",
+        "--sub_target",
+        "cell/pkg:bar[sub2]",
         "--configured_target",
         "root//:t1?root//:macos",
+        "--configured_target",
+        "root//:t1?root//:linux",
     )
 
     golden(


### PR DESCRIPTION
I was surprised to learn that my code which the target exprs were used as a list no longer worked after a buck2 upgrade.
These are documented as being a list, yet they were not actually parsed
as such! https://buck2.build/docs/api/bxl/cli_args/#target_expr

```
def _collect_nix_deps(ctx):
    print(ctx.cli_args)
    pass

main = bxl.main(
    impl = _collect_nix_deps,
    cli_args = {
        "target": bxl.cli_args.target_expr("Target(s) to build and import"),
    },
    doc = """
        Extracts the direct/buck2-transitive Nix dependency list of a buck2 target into a messy json file.
    """,
)
```

Before:

```
$ cargo r -p buck2 -- bxl test.bxl:main -- --target //:foo --target //:bar
   Compiling buck2_bxl v0.1.0 (/Users/jade/co/buck2/app/buck2_bxl)
   Compiling buck2 v0.1.0 (/Users/jade/co/buck2/app/buck2)
    Finished `
dev` profile [optimized + debuginfo] target(s) in 5.84s
     Running 
`
target/debug/buck2 bxl 'test.bxl:main' -- --target '//:foo' --target '//:bar'`
buck2 daemon constraint mismatch: Version mismatch; killing daemon...
Starting new buck2 daemon...
Connected to new buck2 daemon.
error: the argument '--target <target>' cannot be used multiple times
```

After:

```
   Compiling buck2_bxl v0.1.0 (/Users/jade/co/buck2/app/buck2_bxl)
   Compiling buck2 v0.1.0 (/Users/jade/co/buck2/app/buck2)
    Finished 
`
dev` profile [optimized + debuginfo] target(s) in 9.08s
     Running 
`
target/debug/buck2 bxl 'test.bxl:main' -- --target '//:buck2' --target '//:buck2_bundle'`
buck2 daemon constraint mismatch: Version mismatch; killing daemon...
Starting new buck2 daemon...
Connected to new buck2 daemon.
struct(target=[gh_facebook_buck2//:buck2, gh_facebook_buck2//:buck2_bundle])
```

I have no way to run the tests
(
https://github.com/facebook/buck2/issues/1027), so you will have to
forgive my attempt to add a test case here; try getting Claude to fix
the bits I missed.

The OSS build is down due to April Fools, so while I've tested this
locally with some build fix hacks, I don't think the external CI will
say much useful.

Upstream PR: https://github.com/facebook/buck2/pull/1279