### PR TITLE
Fix regression after DirectIoExecutor by default on macOS

### DIFF
--- a/app/buck2_server/src/daemon/state.rs
+++ b/app/buck2_server/src/daemon/state.rs
@@ -399,6 +399,9 @@ impl DaemonState {
             let disk_state_options = DiskStateOptions::new(root_config, materializations.dupe())?;
 
             let blocking_executor: Arc<dyn BlockingExecutor> =
+                // NOTE: Due to this issue: https://github.com/facebook/buck2/issues/1282
+                // We need to revert DirectIoExecutor as a default to BuckBlockingExecutor on macOS.
+                //
                 //if cfg!(any(target_os = "macos", target_os = "windows")) {
                 //    Arc::new(DirectIoExecutor::new(fs.dupe())?)
                 //} else

--- a/app/buck2_server/src/daemon/state.rs
+++ b/app/buck2_server/src/daemon/state.rs
@@ -399,9 +399,10 @@ impl DaemonState {
             let disk_state_options = DiskStateOptions::new(root_config, materializations.dupe())?;
 
             let blocking_executor: Arc<dyn BlockingExecutor> =
-                if cfg!(any(target_os = "macos", target_os = "windows")) {
-                    Arc::new(DirectIoExecutor::new(fs.dupe())?)
-                } else {
+                //if cfg!(any(target_os = "macos", target_os = "windows")) {
+                //    Arc::new(DirectIoExecutor::new(fs.dupe())?)
+                //} else
+                {
                     Arc::new(BuckBlockingExecutor::default_concurrency(fs.dupe())?)
                 };
 

--- a/app/buck2_server_ctx/src/concurrency.rs
+++ b/app/buck2_server_ctx/src/concurrency.rs
@@ -544,12 +544,10 @@ impl ConcurrencyHandler {
                         }
 
                         let is_same_state = transaction.equivalent(&active.version);
-                        println!("transaction.equality_token = {}", transaction.equality_token());
-                        println!("active.version = {}", active.version);
+
                         // If we have a different state, attempt to transition to cleanup. This will
                         // succeed only if the current state is not in use.
                         if !is_same_state {
-                            println!("I AM HERE");
                             // If the active commands are preemptible, preempt them.
                             self.cancel_preemptible_commands(&mut data, is_same_state);
 

--- a/app/buck2_server_ctx/src/concurrency.rs
+++ b/app/buck2_server_ctx/src/concurrency.rs
@@ -544,10 +544,12 @@ impl ConcurrencyHandler {
                         }
 
                         let is_same_state = transaction.equivalent(&active.version);
-
+                        println!("transaction.equality_token = {}", transaction.equality_token());
+                        println!("active.version = {}", active.version);
                         // If we have a different state, attempt to transition to cleanup. This will
                         // succeed only if the current state is not in use.
                         if !is_same_state {
+                            println!("I AM HERE");
                             // If the active commands are preemptible, preempt them.
                             self.cancel_preemptible_commands(&mut data, is_same_state);
 


### PR DESCRIPTION
Regarding this regression: https://github.com/facebook/buck2/issues/1282

It turns out that the original BuckBlockingExecutor behaves better for us at the moment.
