### PR TITLE
Improve reliability and observability of remote exeution gRPC client

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -94,6 +94,7 @@ use tonic::transport::Channel;
 use tonic::transport::Identity;
 use tonic::transport::Uri;
 use tonic::transport::channel::ClientTlsConfig;
+use tracing::debug;
 
 use crate::error::*;
 use crate::metadata::*;
@@ -784,6 +785,9 @@ impl REClient {
             ..Default::default()
         };
 
+        debug!(?request, "RE ACTION REQUEST");
+        debug!(?metadata, "RE ACTION REQUEST METADATA");
+
         let stream = retry(
             || async {
                 let mut client = self.grpc_clients.execution_client.clone();
@@ -809,6 +813,14 @@ impl REClient {
                 None => return Ok(None),
             };
 
+            debug!(?msg, "RE ACTION RESPONSE");
+
+            if let Some(metadata) = &msg.metadata {
+                if let Ok(meta) = ExecuteOperationMetadata::decode(&metadata.value[..]) {
+                    debug!(?meta, "RE ACTION RESPONSE METADATA");
+                }
+            }
+
             let status = if msg.done {
                 match msg
                     .result
@@ -831,6 +843,8 @@ impl REClient {
                         let action_result = execute_response_grpc
                             .result
                             .with_context(|| "The action result is not defined.")?;
+
+                        debug!(?action_result, "BUCK2 ACTION RESULT");
 
                         let action_result = convert_action_result(action_result)?;
 

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -698,6 +698,7 @@ impl REClient {
         request: ActionResultRequest,
     ) -> anyhow::Result<ActionResultResponse> {
         retry(
+            "GetActionResultRequest",
             || async {
                 let mut client = self.grpc_clients.action_cache_client.clone();
                 let request = request.clone();
@@ -734,6 +735,7 @@ impl REClient {
         request: WriteActionResultRequest,
     ) -> anyhow::Result<WriteActionResultResponse> {
         retry(
+            "UpdateActionResult",
             || async {
                 let mut client = self.grpc_clients.action_cache_client.clone();
                 let request = request.clone();
@@ -789,6 +791,7 @@ impl REClient {
         debug!(?metadata, "RE ACTION REQUEST METADATA");
 
         let stream = retry(
+            "Execute",
             || async {
                 let mut client = self.grpc_clients.execution_client.clone();
                 let request = request.clone();
@@ -928,6 +931,7 @@ impl REClient {
                 let runtime_opts = self.runtime_opts;
 
                 retry(
+                    "BatchUpdateBlobs",
                     move || {
                         let metadata = metadata.clone();
                         let mut cas_client = cas_client.clone();
@@ -956,6 +960,7 @@ impl REClient {
                 let runtime_opts = self.runtime_opts;
 
                 retry(
+                    "BS.write",
                     move || {
                         let metadata = metadata.clone();
                         let mut bytestream_client = bytestream_client.clone();
@@ -1021,6 +1026,7 @@ impl REClient {
                 let runtime_opts = self.runtime_opts;
 
                 retry(
+                    "BatchReadBlobs",
                     move || {
                         let metadata = metadata.clone();
                         let mut client = client.clone();
@@ -1049,6 +1055,7 @@ impl REClient {
                 async move {
                     let client = self.grpc_clients.bytestream_client.clone();
                     retry(
+                        "Read",
                         move || {
                             let metadata = metadata.clone();
                             let mut client = client.clone();
@@ -1120,6 +1127,7 @@ impl REClient {
                 tracing::debug!(num_digests = digests_to_check.len(), "FindMissingBlobs");
                 let runtime_opts = self.runtime_opts;
                 let missing_blobs = retry(
+                    "FindMissingBlobs",
                     || {
                         let mut cas_client = cas_client.clone();
                         let metadata = metadata.clone();
@@ -1620,6 +1628,7 @@ where
     Cas: Future<Output = anyhow::Result<BatchReadBlobsResponse>>,
 {
     retry(
+        "BatchReadBlobs",
         || async { cas_f(read_blobs_request.clone()).await },
         opts.max_retries,
         INITIAL_DELAY,

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -1893,7 +1893,6 @@ fn with_re_metadata<T>(
     // Meta builds catch those issues earlier.
 
     let mut msg = tonic::Request::new(t);
-    msg.set_timeout(runtime_opts.rpc_timeout);
 
     if runtime_opts.use_fbcode_metadata {
         // This is pretty ugly, but the protobuf spec that defines this is

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -73,8 +73,8 @@ use re_grpc_proto::google::bytestream::ReadResponse;
 use re_grpc_proto::google::bytestream::WriteRequest;
 use re_grpc_proto::google::bytestream::WriteResponse;
 use re_grpc_proto::google::bytestream::byte_stream_client::ByteStreamClient;
-use re_grpc_proto::google::longrunning::operation::Result as OpResult;
 use re_grpc_proto::google::longrunning::Operation;
+use re_grpc_proto::google::longrunning::operation::Result as OpResult;
 use re_grpc_proto::google::rpc::Code;
 use re_grpc_proto::google::rpc::Status;
 use regex::Regex;
@@ -318,7 +318,7 @@ impl REClientBuilder {
 
         let tls_config = &tls_config;
 
-        let create_channel = |address: Option<String>| async move {
+        let create_channel = |address: Option<String>, with_timeout: bool| async move {
             let address = address.as_ref().context("No address")?;
             let address = substitute_env_vars(address).context("Invalid address")?;
             let uri = address.parse().context("Invalid address")?;
@@ -349,7 +349,14 @@ impl REClientBuilder {
             http.set_keepalive(Some(Duration::from_secs(180)));
             let connector = CountingConnector::new(http);
 
-            endpoint = endpoint.timeout(Duration::from_secs(opts.grpc_timeout));
+            // Apply a per-RPC deadline to all channels except the execution channel.
+            // The Execute RPC is a long-lived stream that stays open for the entire
+            // duration of the remote action (queued + executing), so a fixed short
+            // timeout would spuriously cancel it. All other RPCs are short unary calls
+            // where a deadline is appropriate.
+            if with_timeout {
+                endpoint = endpoint.timeout(Duration::from_secs(opts.grpc_timeout));
+            }
 
             anyhow::Ok(
                 endpoint
@@ -360,11 +367,11 @@ impl REClientBuilder {
         };
 
         let (cas, execution, action_cache, bytestream, capabilities) = futures::future::join5(
-            create_channel(opts.cas_address.clone()),
-            create_channel(opts.engine_address.clone()),
-            create_channel(opts.action_cache_address.clone()),
-            create_channel(opts.cas_address.clone()),
-            create_channel(opts.engine_address.clone()),
+            create_channel(opts.cas_address.clone(), true),
+            create_channel(opts.engine_address.clone(), false), // Execute streams are long-lived; no channel timeout
+            create_channel(opts.action_cache_address.clone(), true),
+            create_channel(opts.cas_address.clone(), true),
+            create_channel(opts.engine_address.clone(), true),
         )
         .await;
 
@@ -688,14 +695,12 @@ fn process_operation_message(msg: Operation) -> anyhow::Result<ExecuteWithProgre
             .result
             .context("Missing `result` when message was `done`")?
         {
-            OpResult::Error(rpc_status) => {
-                Err(REClientError {
-                    code: TCode(rpc_status.code),
-                    message: rpc_status.message,
-                    group: TCodeReasonGroup::UNKNOWN,
-                }
-                .into())
+            OpResult::Error(rpc_status) => Err(REClientError {
+                code: TCode(rpc_status.code),
+                message: rpc_status.message,
+                group: TCodeReasonGroup::UNKNOWN,
             }
+            .into()),
             OpResult::Response(any) => {
                 let execute_response_grpc: GExecuteResponse =
                     GExecuteResponse::decode(&any.value[..])?;
@@ -731,8 +736,7 @@ fn process_operation_message(msg: Operation) -> anyhow::Result<ExecuteWithProgre
             }
         }
     } else {
-        let meta =
-            ExecuteOperationMetadata::decode(&msg.metadata.unwrap_or_default().value[..])?;
+        let meta = ExecuteOperationMetadata::decode(&msg.metadata.unwrap_or_default().value[..])?;
 
         let stage = match execution_stage::Value::try_from(meta.stage) {
             Ok(execution_stage::Value::Unknown) => Stage::UNKNOWN,

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -74,6 +74,7 @@ use re_grpc_proto::google::bytestream::WriteRequest;
 use re_grpc_proto::google::bytestream::WriteResponse;
 use re_grpc_proto::google::bytestream::byte_stream_client::ByteStreamClient;
 use re_grpc_proto::google::longrunning::operation::Result as OpResult;
+use re_grpc_proto::google::longrunning::Operation;
 use re_grpc_proto::google::rpc::Code;
 use re_grpc_proto::google::rpc::Status;
 use regex::Regex;
@@ -101,6 +102,7 @@ use crate::metadata::*;
 use crate::request::*;
 use crate::response::*;
 use crate::retry::retry;
+use crate::retry::retrying_stream;
 use crate::stats::CountingConnector;
 
 const DEFAULT_MAX_TOTAL_BATCH_SIZE: usize = 4 * 1000 * 1000;
@@ -670,6 +672,85 @@ impl BatchUploadReqAggregator {
     }
 }
 
+/// Converts a longrunning `Operation` message received from the Execute streaming RPC into a
+/// `ExecuteWithProgressResponse`. This is extracted so it can be used with `retrying_stream`.
+fn process_operation_message(msg: Operation) -> anyhow::Result<ExecuteWithProgressResponse> {
+    debug!(?msg, "RE ACTION RESPONSE");
+
+    if let Some(metadata) = &msg.metadata {
+        if let Ok(meta) = ExecuteOperationMetadata::decode(&metadata.value[..]) {
+            debug!(?meta, "RE ACTION RESPONSE METADATA");
+        }
+    }
+
+    if msg.done {
+        match msg
+            .result
+            .context("Missing `result` when message was `done`")?
+        {
+            OpResult::Error(rpc_status) => {
+                Err(REClientError {
+                    code: TCode(rpc_status.code),
+                    message: rpc_status.message,
+                    group: TCodeReasonGroup::UNKNOWN,
+                }
+                .into())
+            }
+            OpResult::Response(any) => {
+                let execute_response_grpc: GExecuteResponse =
+                    GExecuteResponse::decode(&any.value[..])?;
+
+                check_status(execute_response_grpc.status.unwrap_or_default())?;
+
+                let action_result = execute_response_grpc
+                    .result
+                    .with_context(|| "The action result is not defined.")?;
+
+                debug!(?action_result, "BUCK2 ACTION RESULT");
+
+                let action_result = convert_action_result(action_result)?;
+
+                let execute_response = ExecuteResponse {
+                    action_result,
+                    action_result_digest: TDigest::default(),
+                    action_result_ttl: 0,
+                    status: TStatus {
+                        code: TCode::OK,
+                        message: execute_response_grpc.message,
+                        ..Default::default()
+                    },
+                    cached_result: execute_response_grpc.cached_result,
+                    action_digest: Default::default(), // Filled in below.
+                };
+
+                Ok(ExecuteWithProgressResponse {
+                    stage: Stage::COMPLETED,
+                    execute_response: Some(execute_response),
+                    ..Default::default()
+                })
+            }
+        }
+    } else {
+        let meta =
+            ExecuteOperationMetadata::decode(&msg.metadata.unwrap_or_default().value[..])?;
+
+        let stage = match execution_stage::Value::try_from(meta.stage) {
+            Ok(execution_stage::Value::Unknown) => Stage::UNKNOWN,
+            Ok(execution_stage::Value::CacheCheck) => Stage::CACHE_CHECK,
+            Ok(execution_stage::Value::Queued) => Stage::QUEUED,
+            Ok(execution_stage::Value::Executing) => Stage::EXECUTING,
+            Ok(execution_stage::Value::Completed) => Stage::COMPLETED,
+            _ => Stage::UNKNOWN,
+        };
+
+        Ok(ExecuteWithProgressResponse {
+            stage,
+            execute_response: None,
+            ..Default::default()
+        })
+    }
+}
+
 impl REClient {
     fn new(
         runtime_opts: RERuntimeOpts,
@@ -790,109 +871,32 @@ impl REClient {
         debug!(?request, "RE ACTION REQUEST");
         debug!(?metadata, "RE ACTION REQUEST METADATA");
 
-        let stream = retry(
+        let execution_client = self.grpc_clients.execution_client.clone();
+        let runtime_opts = self.runtime_opts;
+
+        // retrying_stream covers both stream establishment and stream reading, so errors like
+        // h2 GOAWAY (ENHANCE_YOUR_CALM / "too_many_internal_resets") that surface during
+        // stream reading are retried and cause tonic to reconnect with a fresh h2 connection.
+        let stream = retrying_stream(
             "Execute",
-            || async {
-                let mut client = self.grpc_clients.execution_client.clone();
+            move || {
+                let mut client = execution_client.clone();
                 let request = request.clone();
                 let metadata = metadata.clone();
-
-                let stream = client
-                    .execute(with_re_metadata(request, metadata, self.runtime_opts))
-                    .await?
-                    .into_inner();
-                Ok(stream)
+                async move {
+                    Ok(client
+                        .execute(with_re_metadata(request, metadata, runtime_opts))
+                        .await?
+                        .into_inner())
+                }
             },
             self.runtime_opts.max_retries,
             INITIAL_DELAY,
             MAX_DELAY,
             true,
-        )
-        .await?;
+        );
 
-        let stream = futures::stream::try_unfold(stream, move |mut stream| async {
-            let msg = match stream.try_next().await.context("RE channel error")? {
-                Some(msg) => msg,
-                None => return Ok(None),
-            };
-
-            debug!(?msg, "RE ACTION RESPONSE");
-
-            if let Some(metadata) = &msg.metadata {
-                if let Ok(meta) = ExecuteOperationMetadata::decode(&metadata.value[..]) {
-                    debug!(?meta, "RE ACTION RESPONSE METADATA");
-                }
-            }
-
-            let status = if msg.done {
-                match msg
-                    .result
-                    .context("Missing `result` when message was `done`")?
-                {
-                    OpResult::Error(rpc_status) => {
-                        return Err(REClientError {
-                            code: TCode(rpc_status.code),
-                            message: rpc_status.message,
-                            group: TCodeReasonGroup::UNKNOWN,
-                        }
-                        .into());
-                    }
-                    OpResult::Response(any) => {
-                        let execute_response_grpc: GExecuteResponse =
-                            GExecuteResponse::decode(&any.value[..])?;
-
-                        check_status(execute_response_grpc.status.unwrap_or_default())?;
-
-                        let action_result = execute_response_grpc
-                            .result
-                            .with_context(|| "The action result is not defined.")?;
-
-                        debug!(?action_result, "BUCK2 ACTION RESULT");
-
-                        let action_result = convert_action_result(action_result)?;
-
-                        let execute_response = ExecuteResponse {
-                            action_result,
-                            action_result_digest: TDigest::default(),
-                            action_result_ttl: 0,
-                            status: TStatus {
-                                code: TCode::OK,
-                                message: execute_response_grpc.message,
-                                ..Default::default()
-                            },
-                            cached_result: execute_response_grpc.cached_result,
-                            action_digest: Default::default(), // Filled in below.
-                        };
-
-                        ExecuteWithProgressResponse {
-                            stage: Stage::COMPLETED,
-                            execute_response: Some(execute_response),
-                            ..Default::default()
-                        }
-                    }
-                }
-            } else {
-                let meta =
-                    ExecuteOperationMetadata::decode(&msg.metadata.unwrap_or_default().value[..])?;
-
-                let stage = match execution_stage::Value::try_from(meta.stage) {
-                    Ok(execution_stage::Value::Unknown) => Stage::UNKNOWN,
-                    Ok(execution_stage::Value::CacheCheck) => Stage::CACHE_CHECK,
-                    Ok(execution_stage::Value::Queued) => Stage::QUEUED,
-                    Ok(execution_stage::Value::Executing) => Stage::EXECUTING,
-                    Ok(execution_stage::Value::Completed) => Stage::COMPLETED,
-                    _ => Stage::UNKNOWN,
-                };
-
-                ExecuteWithProgressResponse {
-                    stage,
-                    execute_response: None,
-                    ..Default::default()
-                }
-            };
-
-            anyhow::Ok(Some((status, stream)))
-        });
+        let stream = stream.and_then(|msg| async move { process_operation_message(msg) });
 
         // We fill in the action digest a little later here. We do it this way so we don't have to
         // clone the execute_request into every future we create above.

--- a/remote_execution/oss/re_grpc/src/metadata.rs
+++ b/remote_execution/oss/re_grpc/src/metadata.rs
@@ -13,27 +13,27 @@ use std::collections::BTreeMap;
 pub type TPlatform = crate::grpc::Platform;
 pub type TProperty = crate::grpc::Property;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ActionHistoryInfo {
     pub action_key: String,
     pub disable_retry_on_oom: bool,
     pub _dot_dot: (),
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct BuckInfo {
     pub build_id: String,
     pub version: String,
     pub _dot_dot: (),
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct TClientContextMetadata {
     pub attributes: BTreeMap<String, String>,
     pub _dot_dot: (),
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RemoteExecutionMetadata {
     pub action_history_info: Option<ActionHistoryInfo>,
     pub buck_info: Option<BuckInfo>,

--- a/remote_execution/oss/re_grpc/src/retry.rs
+++ b/remote_execution/oss/re_grpc/src/retry.rs
@@ -7,8 +7,11 @@
  * of this source tree.
  */
 
+use std::sync::Arc;
 use std::time::Duration;
 use std::future::Future;
+use futures::Stream;
+use futures::TryStreamExt;
 use crate::error::{REClientError, TCode};
 use tracing::warn;
 
@@ -112,4 +115,109 @@ fn is_retryable(err: &anyhow::Error, retry_not_found: bool) -> Retryable {
         }
     }
     Retryable::No
+}
+
+/// Like [`retry`], but covers both stream establishment and stream reading.
+///
+/// `make_stream` is called to open the gRPC streaming call. If the call itself fails, or if
+/// reading a message from the resulting stream fails, and the error is retryable, `make_stream`
+/// is called again to establish a fresh stream (which causes tonic to obtain a new h2 connection
+/// when the old one was closed by a GOAWAY frame, e.g. `ENHANCE_YOUR_CALM` /
+/// `"too_many_internal_resets"`).
+///
+/// Items from the stream are yielded progressively to the caller (preserving streaming progress
+/// updates), so this is a drop-in replacement for `retry(make_stream) + try_unfold(try_next)`.
+pub fn retrying_stream<F, Fut, S, T>(
+    method: &'static str,
+    make_stream: F,
+    max_retries: usize,
+    initial_delay: Duration,
+    max_delay: Duration,
+    retry_not_found: bool,
+) -> impl Stream<Item = anyhow::Result<T>> + Send + 'static
+where
+    F: Fn() -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = anyhow::Result<S>> + Send + 'static,
+    S: futures::TryStream<Ok = T, Error = tonic::Status> + Send + Unpin + 'static,
+    T: Send + 'static,
+{
+    struct RetryState<F, S> {
+        make_stream: Arc<F>,
+        stream: Option<S>,
+        retries_left: usize,
+        delay: Duration,
+        max_delay: Duration,
+        retry_not_found: bool,
+    }
+
+    let state = RetryState {
+        make_stream: Arc::new(make_stream),
+        stream: None,
+        retries_left: max_retries,
+        delay: initial_delay,
+        max_delay,
+        retry_not_found,
+    };
+
+    futures::stream::try_unfold(state, move |mut state| async move {
+        loop {
+            // Establish a stream if we don't have one (first call or after a retry).
+            if state.stream.is_none() {
+                match (state.make_stream)().await {
+                    Ok(s) => {
+                        state.stream = Some(s);
+                    }
+                    Err(err) => {
+                        if is_retryable(&err, state.retry_not_found) != Retryable::No
+                            && state.retries_left > 0
+                        {
+                            warn!(
+                                "Retrying {} stream open after error: {}. Attempts remaining: {}",
+                                method,
+                                err,
+                                state.retries_left,
+                            );
+                            tokio::time::sleep(state.delay).await;
+                            state.delay *= 2;
+                            if state.delay > state.max_delay {
+                                state.delay = state.max_delay;
+                            }
+                            state.retries_left -= 1;
+                            continue;
+                        }
+                        return Err(err);
+                    }
+                }
+            }
+
+            // Read the next message from the stream.
+            match state.stream.as_mut().unwrap().try_next().await {
+                Ok(Some(item)) => return Ok(Some((item, state))),
+                Ok(None) => return Ok(None),
+                Err(status) => {
+                    let err = anyhow::Error::from(status);
+                    if is_retryable(&err, state.retry_not_found) != Retryable::No
+                        && state.retries_left > 0
+                    {
+                        warn!(
+                            "Retrying {} stream read after error: {}. Attempts remaining: {}",
+                            method,
+                            err,
+                            state.retries_left,
+                        );
+                        tokio::time::sleep(state.delay).await;
+                        state.delay *= 2;
+                        if state.delay > state.max_delay {
+                            state.delay = state.max_delay;
+                        }
+                        state.retries_left -= 1;
+                        // Drop the broken stream; next iteration re-establishes it.
+                        state.stream = None;
+                        continue;
+                    }
+                    return Err(err);
+                }
+            }
+        }
+    })
 }

--- a/remote_execution/oss/re_grpc/src/retry.rs
+++ b/remote_execution/oss/re_grpc/src/retry.rs
@@ -13,6 +13,7 @@ use crate::error::{REClientError, TCode};
 use tracing::warn;
 
 pub async fn retry<F, Fut, T>(
+    method: &str,
     mut f: F,
     max_retries: usize,
     initial_delay: Duration,
@@ -53,7 +54,10 @@ where
                 };
 
                 if retryable == Retryable::Wait {
-                    warn!("Retrying request after error: {}. Attempt {}/{} (waiting {:?})", msg, retries, max_retries, delay);
+                    warn!(
+                        "Retrying {} request after error: {}. Attempt {}/{} (waiting {:?})",
+                        method, msg, retries, max_retries, delay
+                    );
                     tokio::time::sleep(delay).await;
 
                     delay *= 2;
@@ -61,7 +65,10 @@ where
                         delay = max_delay;
                     }
                 } else {
-                    warn!("Retrying request after error: {}. Attempt {}/{}", msg, retries, max_retries);
+                    warn!(
+                        "Retrying {} request after error: {}. Attempt {}/{}",
+                        method, msg, retries, max_retries
+                    );
                 }
             }
         }


### PR DESCRIPTION
These changes address a failure that surfaced on CI when many actions would be run remotely (> 4000) which would trigger a `too_many_internal_resets` error condition.

Also, debug output for RE actions and metadata information is added which can be enabled by setting the environment variable `BUCK_LOG` to `remote_execution=debug`.

Additionally, this removes the `set_timeout` call per message which has proven to cause trouble in the past and was already included in the patchset applied to buck2-source before but fell through the cracks somehow...

Lastly, this removes the timeout on the execute gRPC channel, which led to many timeout / Cancelled messages and retries.