### PR TITLE
Add upstream fix to sort config dir entries

### DIFF
--- a/app/buck2_common/src/legacy_configs/file_ops.rs
+++ b/app/buck2_common/src/legacy_configs/file_ops.rs
@@ -159,6 +159,7 @@ impl ConfigParserFileOps for DefaultConfigParserFileOps {
                 );
             }
         }
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(entries)
     }
 }


### PR DESCRIPTION
This cherry-picks an upstream fix necessary to have buck2 load config files in a deterministic order.

Summary:
`DefaultConfigParserFileOps::read_dir` uses `std::fs::read_dir` which returns entries in platform-dependent, unspecified order. The DICE-based `ReadDirOutput` is already documented as returning sorted entries, but `DefaultConfigParserFileOps` (used during initial daemon startup) did not match this contract.

This means when buckconfig directories contain multiple files defining the same config key, which value wins could vary across runs depending on filesystem traversal order.

Sort entries by name in `DefaultConfigParserFileOps::read_dir` to match the DICE path's contract and ensure deterministic config resolution.

