### PR TITLE
Allow source labels to omit eponymous target names

### DIFF
--- a/app/buck2_interpreter_for_build/src/attrs/coerce/attr_type/source.rs
+++ b/app/buck2_interpreter_for_build/src/attrs/coerce/attr_type/source.rs
@@ -43,7 +43,7 @@ impl AttrTypeCoerce for SourceAttrType {
     ) -> buck2_error::Result<CoercedAttr> {
         let source_label = value.unpack_str_err()?;
 
-        let label_err = if source_label.contains(':') {
+        let label_err = if source_label.contains(':') || source_label.contains("//") {
             match ctx.coerce_providers_label(source_label) {
                 Ok(l) => return Ok(CoercedAttr::SourceLabel(l)),
                 Err(e) => Some(e),


### PR DESCRIPTION
This allows us to write e.g `//A/B` instead of `//A/B:B` for a source (an attr declared as `attrs.source()`). The existing change allows referring to other eponymous targets with the shorthand, but this optimization for sources breaks it. I've tested this with Mercury's internal code and it appears to work.

This should probably be folded into https://github.com/facebook/buck2/pull/1004 eventually (or we should remove this optimization entirely).