### PR TITLE
buck2_events: Add OpenTelemetry `EventSink`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,10 @@ num_cpus = "1.11"
 num_enum = "0.7"
 object = "0.36.7"
 once_cell = "1.8"
+opentelemetry = "0.32.0"
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client"] }
+opentelemetry-semantic-conventions = { version = "0.32.0", features = ["semconv_experimental"] }
+opentelemetry_sdk = "0.32.1"
 os_str_bytes = { version = "6.6.0", features = ["conversions"] }
 parking_lot = { version = "0.11.2", features = ["send_guard"] }
 paste = "1.0"

--- a/app/buck2/src/lib.rs
+++ b/app/buck2/src/lib.rs
@@ -489,6 +489,23 @@ impl CommandKind {
             recorder.update_for_client_ctx(&command_ctx, self.command_name());
         }
 
+        // Build the client's OTLP exporter now. The client process emits the invocation record (and,
+        // when `tracing`-span export is enabled, the bulk of the spans), and unlike the daemon it
+        // never `fork()`s without an immediate `exec()`, so it is safe to spawn the exporter's
+        // background threads here. Only the client activates today; a future daemon exporter would
+        // have to activate separately, after daemonizing. Skip the forking helpers, which fork+exec
+        // constantly and have nothing to export.
+        #[cfg(not(client_only))]
+        let enable_telemetry = !matches!(
+            self,
+            CommandKind::Forkserver(..) | CommandKind::InternalTestRunner(..)
+        );
+        #[cfg(client_only)]
+        let enable_telemetry = true;
+        if enable_telemetry {
+            buck2_core::logging::otel::activate(BuckVersion::get_version());
+        }
+
         match self {
             #[cfg(not(client_only))]
             CommandKind::Daemon(..) => unreachable!("Checked earlier"),

--- a/app/buck2_client_ctx/src/exit_result.rs
+++ b/app/buck2_client_ctx/src/exit_result.rs
@@ -345,6 +345,12 @@ impl ExitResultVariant {
     pub fn report(self) -> ! {
         // Log the exit timestamp
         tracing::debug!("Client exiting");
+
+        // Drain any buffered OTLP spans before we leave. Every variant below either calls
+        // `libc::_exit` or `exec`s a new process image -- neither runs destructors, so the batch
+        // exporter would otherwise drop its final spans on the floor.
+        // See https://github.com/open-telemetry/opentelemetry-rust/issues/1961.
+        buck2_core::logging::otel::shutdown();
         // NOTE: We use writeln instead of println so we don't panic if stderr is closed. This
         // ensures we get the desired exit code printed instead of potentially a panic.
         let mut exit_code = match self {

--- a/app/buck2_client_ctx/src/subscribers/recorder.rs
+++ b/app/buck2_client_ctx/src/subscribers/recorder.rs
@@ -46,7 +46,6 @@ use buck2_error::buck2_error;
 use buck2_error::classify::ERROR_TAG_UNCLASSIFIED;
 use buck2_error::classify::ErrorLike;
 use buck2_error::classify::source_area;
-use buck2_error::internal_error;
 use buck2_error::source_location::SourceLocation;
 use buck2_event_log::ttl::manifold_event_log_ttl;
 use buck2_event_observer::action_stats;
@@ -56,6 +55,8 @@ use buck2_event_observer::last_command_execution_kind::LastCommandExecutionKind;
 use buck2_event_observer::last_command_execution_kind::get_last_command_execution_time;
 use buck2_events::BuckEvent;
 use buck2_events::daemon_id::DaemonId;
+#[cfg(not(fbcode_build))]
+use buck2_events::sink::otel::new_otel_event_sink_if_enabled;
 use buck2_events::sink::remote::ScribeConfig;
 use buck2_events::sink::remote::new_remote_event_sink_if_enabled;
 use buck2_fs::fs_util;
@@ -2402,6 +2403,20 @@ impl EventSubscriber for InvocationRecorder {
         // Typically initialized already unless the command failed early.
         let fb = buck2_common::fbinit::get_or_init_fbcode_globals();
         let event = self.create_record_event();
+
+        // Send the record to every enabled remote sink. The OTLP sink has the same interface as the
+        // Scribe sink and is not Meta-specific, so it is the export path in OSS builds where the
+        // Scribe sink is a compile-time no-op. Telemetry must never fail a command, so an OTLP
+        // failure is logged rather than propagated.
+        #[cfg(not(fbcode_build))]
+        if let Some(otel_sink) = new_otel_event_sink_if_enabled() {
+            let span = tracing::info_span!("Recording invocation to OpenTelemetry");
+            let _guard = span.enter();
+            if let Err(e) = otel_sink.send_now(event.clone()).await {
+                tracing::warn!("Failed to export invocation record via OTLP: {e:#}");
+            }
+        }
+
         if let Some(scribe_sink) = new_remote_event_sink_if_enabled(
             fb,
             ScribeConfig {
@@ -2416,7 +2431,7 @@ impl EventSubscriber for InvocationRecorder {
             scribe_sink.send_now(event).await
         } else {
             tracing::info!("Invocation record is not sent to Scribe: {:?}", &event);
-            Err(internal_error!("Scribe sink not enabled"))
+            Ok(())
         }
     }
 

--- a/app/buck2_core/Cargo.toml
+++ b/app/buck2_core/Cargo.toml
@@ -17,6 +17,10 @@ indent_write = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
 once_cell = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry-otlp = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }
+opentelemetry_sdk = { workspace = true }
 os_str_bytes = { workspace = true }
 pagable = { workspace = true }
 pin-project = { workspace = true }
@@ -35,6 +39,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 triomphe = { workspace = true }
+uuid = { workspace = true }
 
 allocative = { workspace = true }
 cmp_any = { workspace = true }

--- a/app/buck2_core/src/logging.rs
+++ b/app/buck2_core/src/logging.rs
@@ -23,6 +23,14 @@ use crate::buck2_env;
 
 pub mod log_file;
 
+#[cfg(not(fbcode_build))]
+pub mod otel;
+
+#[cfg(fbcode_build)]
+mod otel_stub;
+#[cfg(fbcode_build)]
+pub use otel_stub as otel;
+
 pub trait LogConfigurationReloadHandle: Send + Sync + 'static {
     fn update_log_filter(&self, format: &str) -> buck2_error::Result<()>;
 }

--- a/app/buck2_core/src/logging/otel.rs
+++ b/app/buck2_core/src/logging/otel.rs
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is dual-licensed under either the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree or the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree. You may select, at your option, one of the
+ * above-listed licenses.
+ */
+
+//! Optional OpenTelemetry (OTLP) export.
+//!
+//! When an OTLP endpoint is configured via the standard `OTEL_EXPORTER_OTLP_*` environment
+//! variables, this module builds an OTLP exporter and tracer provider. Unlike a server, buck2 is a
+//! short-lived CLI process, so the exported resource attributes describe *this invocation* (a fresh
+//! `service.instance.id` per run, the compiled-in `service.version`, the host and pid) rather than a
+//! long-running deployment.
+//!
+//! This module owns only the exporter lifecycle (build, activate, flush). What gets exported is up
+//! to callers: anything that reaches the global provider stored here -- a `tracing` layer bridged on
+//! top, or an out-of-band "wide event" span -- rides the same exporter.
+//!
+//! ## Deferred activation (important)
+//!
+//! The OTLP batch exporter spawns background threads (a batch-processor thread plus an HTTP client
+//! runtime). The buck2 daemon daemonizes via `fork()` *without* a following `exec()`, and `fork()`
+//! only copies the calling thread -- any other thread vanishes in the child but leaves the locks and
+//! state it held (allocator, TLS/crypto, exporter queues) permanently wedged. A daemon that spawned
+//! these threads pre-fork therefore deadlocks or aborts shortly after start. See the
+//! "Do not create any threads before this point" invariant in `buck2_daemon::daemon`.
+//!
+//! So we do *not* build the exporter when the subscriber is installed. [`activate`] builds it later,
+//! once the process is past any such `fork()`. Today only the client calls [`activate`] -- it emits
+//! the invocation record and never `fork()`s-without-`exec()`. If the daemon ever exports its own
+//! spans it must call [`activate`] only after it has finished daemonizing, never before.
+//!
+//! ## Flushing
+//!
+//! Spans are buffered and only flushed periodically. buck2 exits via `libc::_exit` (see
+//! `ExitResult::report`), which runs no destructors, so the buffered batch would be dropped unless
+//! we drain it explicitly. [`shutdown`] does that drain and must be called on every exit path. See
+//! <https://github.com/open-telemetry/opentelemetry-rust/issues/1961>.
+
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::SystemTime;
+
+use buck2_error::conversion::from_any_with_tag;
+use opentelemetry::KeyValue;
+use opentelemetry::trace::Span as _;
+use opentelemetry::trace::Tracer as _;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::Protocol;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::trace::BatchConfigBuilder;
+use opentelemetry_sdk::trace::BatchSpanProcessor;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::trace::SpanLimits;
+use opentelemetry_semantic_conventions::resource::HOST_ARCH;
+use opentelemetry_semantic_conventions::resource::HOST_NAME;
+use opentelemetry_semantic_conventions::resource::OS_TYPE;
+use opentelemetry_semantic_conventions::resource::PROCESS_PID;
+use opentelemetry_semantic_conventions::resource::SERVICE_INSTANCE_ID;
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+use opentelemetry_semantic_conventions::resource::SERVICE_VERSION;
+use uuid::Uuid;
+
+/// The active OTLP tracer provider, if any. Stored globally so that [`shutdown`] can reach it from
+/// the process exit path (which lives in a different crate, and runs after any layer's type has been
+/// erased into the global subscriber) and so out-of-band emitters can reuse the same exporter.
+///
+/// We can't use [`opentelemetry::global::tracer_provider`] here because that produces a
+/// [`opentelemetry::global::GlobalTracerProvider`], which lacks the
+/// [`opentelemetry_sdk::trace::SdkTracerProvider::shutdown`] method we actually need to call.
+static PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+
+/// Guards [`activate`] so the exporter is built at most once, even if it is called from more than one
+/// entry point (today just the client, before running a command; a future daemon exporter, which
+/// would activate after daemonizing, would be a second).
+static ACTIVATED: AtomicBool = AtomicBool::new(false);
+
+/// We only enable OTLP export when an endpoint is explicitly configured. This keeps the common case
+/// (no telemetry) free of overhead and avoids futile connection attempts to the default
+/// `localhost:4318`. These are standard OpenTelemetry variables read by the exporter itself, not
+/// buck2-owned configuration, so we check them directly rather than registering them via
+/// `buck2_env!` (which would surface them misleadingly in `buck2 help-env`).
+fn otlp_endpoint_configured() -> bool {
+    [
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+    ]
+    .iter()
+    .any(|var| std::env::var_os(var).is_some_and(|v| !v.is_empty()))
+}
+
+/// Map Rust's [`std::env::consts::OS`] to the OpenTelemetry `os.type` value set, passing through any
+/// value without a standardized equivalent (e.g. `ios`, `android`) as-is. Most names already match;
+/// only a couple are spelled differently.
+fn otel_os_type(os: &str) -> &str {
+    match os {
+        "macos" => "darwin",
+        "dragonfly" => "dragonflybsd",
+        // `linux`, `windows`, `freebsd`, `netbsd`, `openbsd`, `solaris`, `aix` already match.
+        other => other,
+    }
+}
+
+/// Map Rust's [`std::env::consts::ARCH`] to the OpenTelemetry `host.arch` value set, passing through
+/// any value without a standardized equivalent (e.g. `riscv64`, `loongarch64`) as-is.
+fn otel_host_arch(arch: &str) -> &str {
+    match arch {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        "arm" => "arm32",
+        "powerpc" => "ppc32",
+        "powerpc64" => "ppc64",
+        // `x86` and `s390x` already match.
+        other => other,
+    }
+}
+
+/// Resource attributes identifying this build invocation, following OpenTelemetry semantic
+/// conventions (<https://opentelemetry.io/docs/specs/semconv/resource/>).
+fn resource(version: &'static str) -> Resource {
+    let mut attributes = vec![
+        KeyValue::new(SERVICE_NAME, "buck2"),
+        // buck2 is not a deployed service, so `service.version` is just this binary's build version.
+        // The caller passes it in (`BuckVersion::get_version()`, the same string `buck2 --version`
+        // prints) because the richer version -- the source revision stamped at build time via
+        // `BUCK2_SET_EXPLICIT_VERSION` -- is only resolvable in the `buck2` bin crate, not here. It
+        // falls back to the binary's build-id when no revision is stamped.
+        KeyValue::new(SERVICE_VERSION, version),
+        // Every buck2 process is its own "instance"; a fresh v4 UUID keeps invocations distinct.
+        //
+        // NB: This is not the build ID / trace ID, which is _also_ written as a v4 UUID.
+        KeyValue::new(SERVICE_INSTANCE_ID, Uuid::new_v4().to_string()),
+        KeyValue::new(HOST_ARCH, otel_host_arch(std::env::consts::ARCH)),
+        KeyValue::new(OS_TYPE, otel_os_type(std::env::consts::OS)),
+        KeyValue::new(PROCESS_PID, i64::from(std::process::id())),
+    ];
+    if let Ok(Some(hostname)) = hostname::get().map(|h| h.into_string().ok()) {
+        attributes.push(KeyValue::new(HOST_NAME, hostname));
+    }
+    Resource::builder().with_attributes(attributes).build()
+}
+
+/// Build the OTLP exporter and tracer provider (spawning the exporter's background threads) and store
+/// the provider in [`PROVIDER`]. No-op when no endpoint is configured.
+fn build_provider(version: &'static str) -> buck2_error::Result<()> {
+    if !otlp_endpoint_configured() {
+        return Ok(());
+    }
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .build()
+        .map_err(|e| from_any_with_tag(e, buck2_error::ErrorTag::Tier0))?;
+
+    let batch_config = BatchConfigBuilder::default().build();
+    let processor = BatchSpanProcessor::builder(exporter)
+        .with_batch_config(batch_config)
+        .build();
+
+    let provider = SdkTracerProvider::builder()
+        // The default settings limit all of these values at 128, which is small enough to start
+        // dropping data on our `InvocationRecord`s!
+        .with_span_limits(SpanLimits {
+            max_events_per_span: 1024,
+            max_attributes_per_span: 2048,
+            max_links_per_span: 512,
+            max_attributes_per_event: 2048,
+            max_attributes_per_link: 1024,
+        })
+        .with_resource(resource(version))
+        .with_span_processor(processor)
+        .build();
+
+    // `activate` runs once, so ignore an already-set slot.
+    let _ = PROVIDER.set(provider);
+
+    Ok(())
+}
+
+/// Emit a fully-assembled "wide event" as a single span, out-of-band from the `tracing` subscriber.
+///
+/// Most spans are accumulated from nested `tracing` spans, but some records -- notably the
+/// end-of-invocation `InvocationRecord` -- are assembled once as a flat field set. OTLP backends
+/// (Honeycomb and friends) ingest a span as a single wide row, so we ship such a record as one span
+/// whose `attributes` are its fields and whose start/end bracket the invocation.
+///
+/// This is intentionally dumb: the caller hands us the finished attribute set (it owns the mapping
+/// from its domain type to keys/values), and we just attach it to a span. The span is enqueued on
+/// the same batch processor as every other span and flushed by [`shutdown`], so it must be emitted
+/// before the process exits. No-op when telemetry was never activated (no endpoint configured, or
+/// [`activate`] not yet called). Because it reuses the global provider, it must only be called after
+/// any `fork()`-without-`exec()` -- in practice it is only emitted by the client at
+/// end-of-invocation, which never forks that way.
+pub fn export_span(
+    name: &'static str,
+    start: SystemTime,
+    end: SystemTime,
+    attributes: Vec<KeyValue>,
+) {
+    let Some(provider) = PROVIDER.get() else {
+        return;
+    };
+
+    let tracer = provider.tracer("buck2");
+    let mut span = tracer
+        .span_builder(name)
+        .with_start_time(start)
+        .with_attributes(attributes)
+        .start(&tracer);
+    span.end_with_timestamp(end);
+}
+
+/// Build the OTLP exporter and start exporting, if telemetry is configured.
+///
+/// This spawns the exporter's background threads, so it MUST be called only after the process has
+/// finished any `fork()`-without-`exec()`. Today only the client calls it, before running a command
+/// (the client never `fork()`s-without-`exec()`, so any time is fine); a future daemon exporter would
+/// have to call it only after daemonizing. Idempotent: the exporter is built at most once. No-op if
+/// telemetry is not configured.
+/// Errors are logged rather than propagated -- telemetry must never fail a command.
+///
+/// `version` is recorded as the `service.version` resource attribute; pass
+/// `BuckVersion::get_version()` (the string `buck2 --version` prints).
+pub fn activate(version: &'static str) {
+    if ACTIVATED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    if let Err(e) = build_provider(version) {
+        tracing::warn!("Failed to start OpenTelemetry exporter: {e}");
+    }
+}
+
+/// Whether the OTLP exporter is built and exporting (i.e. [`activate`] ran and an endpoint was
+/// configured). Lets callers skip building span attributes when nothing would consume them --
+/// [`export_span`] is itself a no-op in that case, but assembling its attributes is not free.
+pub fn is_active() -> bool {
+    PROVIDER.get().is_some()
+}
+
+/// Flush and shut down the OTLP exporter, draining any spans still buffered in the batch processor.
+///
+/// This must be called before the process exits. buck2 exits via `libc::_exit`, which runs no
+/// destructors, so without this the final batch of spans is silently lost. No-op when OTLP export
+/// was never activated.
+pub fn shutdown() {
+    if let Some(provider) = PROVIDER.get() {
+        // Best-effort: we are on the way out regardless, so a failed flush only costs us the last
+        // batch of spans.
+        if let Err(e) = provider.shutdown() {
+            tracing::warn!("Failed to shut down OpenTelemetry exporter on exit: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn os_type_remaps_and_passes_through() {
+        // Rust spellings that differ from the OpenTelemetry value set.
+        assert_eq!(otel_os_type("macos"), "darwin");
+        assert_eq!(otel_os_type("dragonfly"), "dragonflybsd");
+        // Already-conformant values are unchanged.
+        assert_eq!(otel_os_type("linux"), "linux");
+        assert_eq!(otel_os_type("windows"), "windows");
+        // No standardized equivalent: passed through as-is.
+        assert_eq!(otel_os_type("ios"), "ios");
+        assert_eq!(otel_os_type("android"), "android");
+    }
+
+    #[test]
+    fn host_arch_remaps_and_passes_through() {
+        assert_eq!(otel_host_arch("x86_64"), "amd64");
+        assert_eq!(otel_host_arch("aarch64"), "arm64");
+        assert_eq!(otel_host_arch("arm"), "arm32");
+        assert_eq!(otel_host_arch("powerpc"), "ppc32");
+        assert_eq!(otel_host_arch("powerpc64"), "ppc64");
+        // Already-conformant values are unchanged.
+        assert_eq!(otel_host_arch("x86"), "x86");
+        assert_eq!(otel_host_arch("s390x"), "s390x");
+        // No standardized equivalent: passed through as-is.
+        assert_eq!(otel_host_arch("riscv64"), "riscv64");
+    }
+
+    /// The live host's arch/os must map to a value the OpenTelemetry spec actually defines (this
+    /// catches a Rust target whose spelling we have not remapped).
+    #[test]
+    fn current_host_is_conformant() {
+        const OS_TYPES: &[&str] = &[
+            "windows",
+            "linux",
+            "darwin",
+            "freebsd",
+            "netbsd",
+            "openbsd",
+            "dragonflybsd",
+            "hpux",
+            "aix",
+            "solaris",
+            "z_os",
+            "zos",
+        ];
+        const HOST_ARCHES: &[&str] = &[
+            "amd64", "arm32", "arm64", "ia64", "ppc32", "ppc64", "s390x", "x86",
+        ];
+
+        // These hold on every platform buck2 currently builds for; a new target that needs a remap
+        // would trip one of them rather than silently emitting a non-conformant value.
+        assert!(
+            OS_TYPES.contains(&otel_os_type(std::env::consts::OS)),
+            "os.type {:?} is not an OpenTelemetry-defined value",
+            otel_os_type(std::env::consts::OS)
+        );
+        assert!(
+            HOST_ARCHES.contains(&otel_host_arch(std::env::consts::ARCH)),
+            "host.arch {:?} is not an OpenTelemetry-defined value",
+            otel_host_arch(std::env::consts::ARCH)
+        );
+    }
+}

--- a/app/buck2_core/src/logging/otel_stub.rs
+++ b/app/buck2_core/src/logging/otel_stub.rs
@@ -1,0 +1,12 @@
+//! Stub of [`crate::logging::otel`] for Meta, with empty implementations.
+//!
+//! Note that this module provides no `export_span` equivalent, because that function takes an
+//! [`opentelemetry::KeyValue`] as a parameter.
+
+pub fn activate(version: &'static str) {}
+
+pub fn is_active() -> bool {
+    false
+}
+
+pub fn shutdown() {}

--- a/app/buck2_events/Cargo.toml
+++ b/app/buck2_events/Cargo.toml
@@ -12,7 +12,10 @@ derive_more = { workspace = true }
 futures = { workspace = true }
 hostname = { workspace = true }
 is_proc_translated = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }
 pin-project = { workspace = true }
+prost-types = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
 sys-info = { workspace = true }

--- a/app/buck2_events/src/sink.rs
+++ b/app/buck2_events/src/sink.rs
@@ -12,6 +12,10 @@
 //! sink during normal operation.
 pub(crate) mod channel;
 pub mod null;
+#[cfg(not(fbcode_build))]
+pub mod otel;
+#[cfg(not(fbcode_build))]
+pub(crate) mod otel_record;
 pub mod remote;
 #[cfg(fbcode_build)]
 pub(crate) mod scribe;

--- a/app/buck2_events/src/sink/otel.rs
+++ b/app/buck2_events/src/sink/otel.rs
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is dual-licensed under either the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree or the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree. You may select, at your option, one of the
+ * above-listed licenses.
+ */
+
+//! An event sink that exports the end-of-invocation [`InvocationRecord`](buck2_data::InvocationRecord)
+//! to OpenTelemetry (OTLP) as a single "wide event" span.
+//!
+//! This is a peer of the Scribe [`RemoteEventSink`](crate::sink::remote::RemoteEventSink): it has
+//! the same shape (`send_now` / `send_messages_now` / `offer` / [`EventSink`]) so callers route the
+//! record to it exactly as they route to Scribe, with no special-casing. Unlike Scribe it is not
+//! Meta-specific, so it is the wide-event export path in open-source builds too.
+//!
+//! The actual proto -> attribute mapping lives in [`crate::sink::otel_record`]; spans are emitted
+//! through [`buck2_core::logging::otel`], which owns the exporter lifecycle (activation after the
+//! daemon fork, flushing on exit).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+
+use crate::BuckEvent;
+use crate::Event;
+use crate::EventSink;
+use crate::EventSinkStats;
+use crate::EventSinkWithStats;
+use crate::sink::otel_record::invocation_record_attributes;
+
+/// Forwards the invocation record to the process-wide OTLP exporter as a span.
+pub struct OtelEventSink;
+
+impl OtelEventSink {
+    pub fn new() -> OtelEventSink {
+        OtelEventSink
+    }
+
+    /// Export the event now. The OTLP batch processor accepts spans synchronously and is drained by
+    /// `buck2_core::logging::otel::shutdown` on exit, so there is nothing to await -- the `async`
+    /// signature exists only to match [`RemoteEventSink`](crate::sink::remote::RemoteEventSink).
+    pub async fn send_now(&self, event: BuckEvent) -> buck2_error::Result<()> {
+        Self::export(&event);
+        Ok(())
+    }
+
+    pub async fn send_messages_now(&self, events: Vec<BuckEvent>) -> buck2_error::Result<()> {
+        for event in &events {
+            Self::export(event);
+        }
+        Ok(())
+    }
+
+    pub fn offer(&self, event: BuckEvent) {
+        Self::export(&event);
+    }
+
+    /// Translate an invocation-record event into an OTLP span. Events that are not an
+    /// `InvocationRecord` are ignored -- this sink only produces the wide event.
+    fn export(event: &BuckEvent) {
+        let buck2_data::buck_event::Data::Record(record_event) = event.data() else {
+            return;
+        };
+        let Some(buck2_data::record_event::Data::InvocationRecord(record)) = &record_event.data
+        else {
+            return;
+        };
+
+        // The span brackets the invocation: it ends when the record was emitted and started
+        // `client_walltime` earlier (the walltime the client measured for the whole command).
+        let end = event.timestamp();
+        let walltime = record
+            .client_walltime
+            .as_ref()
+            .map(|d| Duration::new(d.seconds.max(0) as u64, d.nanos.max(0) as u32))
+            .unwrap_or_default();
+        let start = end.checked_sub(walltime).unwrap_or(end);
+
+        let mut attributes = invocation_record_attributes(record);
+        // The invocation's trace UUID lives on the event envelope, not in the record payload, but
+        // it is the primary correlation key (it ties this wide event to the event log and to any
+        // other telemetry for the same invocation), so attach it explicitly.
+        if let Ok(trace_id) = event.trace_id() {
+            attributes.push(KeyValue::new("buck2.trace_id", trace_id.to_string()));
+        }
+        // NB: The event isn't necessarily a 'build' in the strict sense (this also fires for tests,
+        // queries, etc.), but this matches Meta's `buck2_builds` table upstream.
+        buck2_core::logging::otel::export_span("buck2_build", start, end, attributes);
+    }
+}
+
+impl EventSink for OtelEventSink {
+    fn send(&self, event: Event) {
+        if let Event::Buck(event) = event {
+            Self::export(&event);
+        }
+    }
+}
+
+impl EventSinkWithStats for OtelEventSink {
+    fn to_event_sync(self: Arc<Self>) -> Arc<dyn EventSink> {
+        self as _
+    }
+
+    fn stats(&self) -> EventSinkStats {
+        // The exporter owns its own buffering/retry accounting; this sink keeps no counters.
+        EventSinkStats {
+            successes: 0,
+            failures_invalid_request: 0,
+            failures_unauthorized: 0,
+            failures_rate_limited: 0,
+            failures_pushed_back: 0,
+            failures_enqueue_failed: 0,
+            failures_internal_error: 0,
+            failures_timed_out: 0,
+            failures_unknown: 0,
+            buffered: 0,
+            dropped: 0,
+            bytes_written: 0,
+        }
+    }
+}
+
+/// Construct an OTLP sink, or `None` when OTLP export is not active (no endpoint configured, or the
+/// exporter was never activated). Mirrors
+/// [`new_remote_event_sink_if_enabled`](crate::sink::remote::new_remote_event_sink_if_enabled) so
+/// the two remote sinks are constructed and used identically.
+pub fn new_otel_event_sink_if_enabled() -> Option<OtelEventSink> {
+    if buck2_core::logging::otel::is_active() {
+        Some(OtelEventSink::new())
+    } else {
+        None
+    }
+}

--- a/app/buck2_events/src/sink/otel_record.rs
+++ b/app/buck2_events/src/sink/otel_record.rs
@@ -1,0 +1,1561 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is dual-licensed under either the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree or the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree. You may select, at your option, one of the
+ * above-listed licenses.
+ */
+
+//! Maps an [`InvocationRecord`](buck2_data::InvocationRecord) to OTLP span attributes for the
+//! end-of-invocation "wide event".
+//!
+//! Every field is mapped *explicitly*, by hand, rather than by serializing the proto and flattening
+//! it generically. This matches how the upstream Scuba pipeline curates its schema: the shape of
+//! each column (key name, unit, how repeated/nested values are projected) is a deliberate choice,
+//! not a mechanical consequence of the proto layout. Attribute keys follow the proto's own
+//! serde field names so they line up with the event-log JSON (durations as `_us` micros, etc.).
+//!
+//! Repeated scalar fields become a single multi-valued attribute (the OTLP equivalent of a Scuba
+//! normvector). Repeated *messages* are projected field-wise into parallel multi-valued attributes
+//! (`errors.category`, `errors.message`, ...), since a list of structs has no single-column form.
+//!
+//! ## Attribute namespacing
+//!
+//! Every attribute is emitted under the `buck2.` namespace (e.g. `re_session_id` becomes
+//! `buck2.re_session_id`), *except* for the handful of fields that correspond to an existing
+//! OpenTelemetry [semantic convention], which are emitted under the standardized attribute name
+//! (taken from the [`opentelemetry_semantic_conventions`] crate) so backends can interpret them
+//! generically. The prefixing is centralized in [`Attrs::push`]; the standardized fields opt out
+//! via the `*_std` helpers and the [`opentelemetry_semantic_conventions::attribute`] constants.
+//!
+//! The mapped fields are `cli_args` -> `process.command_args`, `exit_code` -> `process.exit.code`,
+//! `git_revision`/`hg_revision` -> `vcs.ref.head.revision` (the current checkout), and
+//! `file_watcher_stats.branched_from_revision` -> `vcs.ref.base.revision` (the mergebase it
+//! branched from). The structured `version_control_revision` sub-message carries the same revision
+//! as the top-level `git_revision`/`hg_revision`, so it stays under `buck2.` to avoid emitting
+//! `vcs.ref.head.revision` twice.
+//!
+//! [semantic convention]: https://opentelemetry.io/docs/specs/semconv/
+
+use std::collections::HashMap;
+
+use opentelemetry::Array;
+use opentelemetry::Key;
+use opentelemetry::KeyValue;
+use opentelemetry::StringValue;
+use opentelemetry::Value;
+use opentelemetry_semantic_conventions::attribute::PROCESS_COMMAND_ARGS;
+use opentelemetry_semantic_conventions::attribute::PROCESS_EXIT_CODE;
+use opentelemetry_semantic_conventions::attribute::VCS_REF_BASE_REVISION;
+use opentelemetry_semantic_conventions::attribute::VCS_REF_HEAD_REVISION;
+
+/// Accumulates OTLP attributes while keeping each field mapping to a single readable line. The
+/// helpers centralise the `Option`/unit/empty-skipping conventions so the mapping below reads as a
+/// flat list of "field -> key" decisions.
+#[derive(Default)]
+struct Attrs {
+    attrs: Vec<KeyValue>,
+}
+
+impl Attrs {
+    /// Push an attribute under the `buck2.` namespace. All buck2-specific keys funnel through here
+    /// so the prefixing is applied in exactly one place; fields that map onto an OpenTelemetry
+    /// semantic convention bypass it via [`Attrs::push_std`].
+    fn push(&mut self, key: impl Into<Key>, value: impl Into<Value>) {
+        let key = key.into();
+        self.attrs.push(KeyValue::new(
+            Key::new(format!("buck2.{}", key.as_str())),
+            value.into(),
+        ));
+    }
+
+    /// Push an attribute under a key taken verbatim from the OpenTelemetry semantic conventions (no
+    /// `buck2.` prefix).
+    fn push_std(&mut self, key: impl Into<Key>, value: impl Into<Value>) {
+        self.attrs.push(KeyValue::new(key, value.into()));
+    }
+
+    /// Resolve the accumulated attributes into the final list, deduplicating by key with last-write
+    /// wins. OTLP attributes are keyed by name, so a duplicate key is invalid; the dynamic
+    /// key-value maps (`metadata`, `client_metadata`, `install_device_metadata`) can in principle
+    /// produce one (e.g. two install devices sharing an entry key), and overwriting keeps the event
+    /// usable rather than emitting an ambiguous pair. First-seen position is preserved.
+    fn into_attrs(self) -> Vec<KeyValue> {
+        let mut index: HashMap<String, usize> = HashMap::new();
+        let mut deduped: Vec<KeyValue> = Vec::with_capacity(self.attrs.len());
+        for kv in self.attrs {
+            match index.get(kv.key.as_str()) {
+                Some(&i) => deduped[i] = kv,
+                None => {
+                    index.insert(kv.key.as_str().to_owned(), deduped.len());
+                    deduped.push(kv);
+                }
+            }
+        }
+        deduped
+    }
+
+    fn string(&mut self, key: impl Into<Key>, v: impl Into<String>) {
+        self.push(key, v.into());
+    }
+
+    fn opt_string(&mut self, key: impl Into<Key>, v: Option<impl Into<String>>) {
+        if let Some(v) = v {
+            self.string(key, v);
+        }
+    }
+
+    /// As [`Attrs::opt_string`], but emitted under a verbatim semantic-convention key.
+    fn opt_string_std(&mut self, key: impl Into<Key>, v: Option<impl Into<String>>) {
+        if let Some(v) = v {
+            self.push_std(key, v.into());
+        }
+    }
+
+    /// Integer-valued attribute. OTLP only has `i64`, so anything that does not fit (a `u64` past
+    /// `i64::MAX`) is dropped rather than silently wrapping; in practice these are counts/sizes that
+    /// never approach the limit.
+    fn int(&mut self, key: impl Into<Key>, v: impl TryInto<i64>) {
+        if let Ok(v) = v.try_into() {
+            self.push(key, v);
+        }
+    }
+
+    fn opt_int<T: TryInto<i64>>(&mut self, key: impl Into<Key>, v: Option<T>) {
+        if let Some(v) = v {
+            self.int(key, v);
+        }
+    }
+
+    /// As [`Attrs::opt_int`], but emitted under a verbatim semantic-convention key.
+    fn opt_int_std<T: TryInto<i64>>(&mut self, key: impl Into<Key>, v: Option<T>) {
+        if let Some(v) = v
+            && let Ok(v) = v.try_into()
+        {
+            self.push_std(key, v);
+        }
+    }
+
+    fn float(&mut self, key: impl Into<Key>, v: f64) {
+        self.push(key, v);
+    }
+
+    fn opt_float(&mut self, key: impl Into<Key>, v: Option<f64>) {
+        if let Some(v) = v {
+            self.float(key, v);
+        }
+    }
+
+    fn bool(&mut self, key: impl Into<Key>, v: bool) {
+        self.push(key, v);
+    }
+
+    fn opt_bool(&mut self, key: impl Into<Key>, v: Option<bool>) {
+        if let Some(v) = v {
+            self.bool(key, v);
+        }
+    }
+
+    /// A `google.protobuf.Duration` as integer microseconds, matching the `_us` serde convention.
+    fn opt_duration_us(&mut self, key: impl Into<Key>, v: Option<&::prost_types::Duration>) {
+        if let Some(d) = v {
+            let micros = d.seconds * 1_000_000 + i64::from(d.nanos) / 1_000;
+            self.int(key, micros);
+        }
+    }
+
+    /// A repeated scalar field as a single homogeneous string array. Skipped when empty (an empty
+    /// array carries no information and just adds a column).
+    fn strings<I, S>(&mut self, key: impl Into<Key>, vs: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let vs: Vec<StringValue> = vs
+            .into_iter()
+            .map(|s| StringValue::from(s.into()))
+            .collect();
+        if !vs.is_empty() {
+            self.push(key, Value::Array(Array::String(vs)));
+        }
+    }
+
+    /// As [`Attrs::strings`], but emitted under a verbatim semantic-convention key.
+    fn strings_std<I, S>(&mut self, key: impl Into<Key>, vs: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let vs: Vec<StringValue> = vs
+            .into_iter()
+            .map(|s| StringValue::from(s.into()))
+            .collect();
+        if !vs.is_empty() {
+            self.push_std(key, Value::Array(Array::String(vs)));
+        }
+    }
+
+    /// A repeated bool field as a single homogeneous bool array. Skipped when empty.
+    fn bools<I>(&mut self, key: impl Into<Key>, vs: I)
+    where
+        I: IntoIterator<Item = bool>,
+    {
+        let vs: Vec<bool> = vs.into_iter().collect();
+        if !vs.is_empty() {
+            self.push(key, Value::Array(Array::Bool(vs)));
+        }
+    }
+}
+
+/// Map every field of an [`InvocationRecord`](buck2_data::InvocationRecord) to OTLP span attributes.
+pub(crate) fn invocation_record_attributes(record: &buck2_data::InvocationRecord) -> Vec<KeyValue> {
+    let mut a = Attrs::default();
+
+    // Marker so backends can segment this wide event from buck2's fine-grained action/analysis
+    // spans (e.g. into a dedicated Honeycomb dataset/view).
+    a.string("event_type", "invocation_record");
+
+    // -- Identity / command ------------------------------------------------------------------
+    a.string("re_session_id", record.re_session_id.clone());
+    // `cli_args` is the full argv as received by the process -- OTel `process.command_args`.
+    a.strings_std(PROCESS_COMMAND_ARGS, record.cli_args.iter().cloned());
+    a.string("filesystem", record.filesystem.clone());
+    a.opt_string("isolation_dir", record.isolation_dir.clone());
+    a.opt_string("command_name", record.command_name.clone());
+    a.opt_string("test_info", record.test_info.clone());
+    a.strings("tags", record.tags.iter().cloned());
+    a.string("re_experiment_name", record.re_experiment_name.clone());
+    a.opt_string("restarted_trace_id", record.restarted_trace_id.clone());
+    a.strings(
+        "concurrent_command_ids",
+        record.concurrent_command_ids.iter().cloned(),
+    );
+    a.opt_string("preemptible", record.preemptible.clone());
+    a.opt_string(
+        "previous_uuid_with_mismatched_config",
+        record.previous_uuid_with_mismatched_config.clone(),
+    );
+
+    // -- Durations (microseconds) ------------------------------------------------------------
+    a.opt_duration_us("command_duration_us", record.command_duration.as_ref());
+    a.opt_duration_us("client_walltime_us", record.client_walltime.as_ref());
+    a.opt_duration_us(
+        "critical_path_duration_us",
+        record.critical_path_duration.as_ref(),
+    );
+    a.opt_duration_us(
+        "concurrent_command_blocking_duration_us",
+        record.concurrent_command_blocking_duration.as_ref(),
+    );
+    a.opt_duration_us(
+        "bxl_ensure_artifacts_duration_us",
+        record.bxl_ensure_artifacts_duration.as_ref(),
+    );
+    a.opt_duration_us("install_duration_us", record.install_duration.as_ref());
+
+    // -- Action execution counts -------------------------------------------------------------
+    a.int("run_local_count", record.run_local_count);
+    a.int("run_remote_count", record.run_remote_count);
+    a.int("run_action_cache_count", record.run_action_cache_count);
+    a.int("run_skipped_count", record.run_skipped_count);
+    a.opt_int("run_fallback_count", record.run_fallback_count);
+    a.opt_int(
+        "run_fallback_re_queue_count",
+        record.run_fallback_re_queue_count,
+    );
+    a.opt_int("run_local_only_count", record.run_local_only_count);
+    a.opt_int(
+        "local_actions_executed_via_worker",
+        record.local_actions_executed_via_worker,
+    );
+    a.int(
+        "run_remote_dep_file_cache_count",
+        record.run_remote_dep_file_cache_count,
+    );
+    a.opt_int(
+        "run_command_failure_count",
+        record.run_command_failure_count,
+    );
+
+    // -- Cache / uploads ---------------------------------------------------------------------
+    a.int("cache_upload_count", record.cache_upload_count);
+    a.int(
+        "cache_upload_attempt_count",
+        record.cache_upload_attempt_count,
+    );
+    a.int("dep_file_upload_count", record.dep_file_upload_count);
+    a.int(
+        "dep_file_upload_attempt_count",
+        record.dep_file_upload_attempt_count,
+    );
+    a.float("cache_hit_rate", f64::from(record.cache_hit_rate));
+    a.int(
+        "min_build_count_since_rebase",
+        record.min_build_count_since_rebase,
+    );
+    a.int(
+        "min_attempted_build_count_since_rebase",
+        record.min_attempted_build_count_since_rebase,
+    );
+
+    // -- Build graph / analysis --------------------------------------------------------------
+    a.opt_int("analysis_count", record.analysis_count);
+    a.opt_int("load_count", record.load_count);
+    a.opt_int("event_count", record.event_count);
+    a.opt_int(
+        "materialization_output_size",
+        record.materialization_output_size,
+    );
+    a.opt_int("materialization_files", record.materialization_files);
+    a.strings(
+        "target_rule_type_names",
+        record.target_rule_type_names.iter().cloned(),
+    );
+
+    // -- "Time to X" latency milestones (milliseconds) ---------------------------------------
+    a.opt_int(
+        "max_event_client_delay_ms",
+        record.max_event_client_delay_ms,
+    );
+    a.opt_int(
+        "time_to_first_action_execution_ms",
+        record.time_to_first_action_execution_ms,
+    );
+    a.opt_int("time_to_command_start_ms", record.time_to_command_start_ms);
+    a.opt_int(
+        "time_to_command_critical_section_ms",
+        record.time_to_command_critical_section_ms,
+    );
+    a.opt_int(
+        "time_to_first_analysis_ms",
+        record.time_to_first_analysis_ms,
+    );
+    a.opt_int(
+        "time_to_load_first_build_file_ms",
+        record.time_to_load_first_build_file_ms,
+    );
+    a.opt_int(
+        "time_to_first_command_execution_start_ms",
+        record.time_to_first_command_execution_start_ms,
+    );
+    a.opt_int(
+        "time_to_last_action_execution_end_ms",
+        record.time_to_last_action_execution_end_ms,
+    );
+    a.opt_int(
+        "time_to_first_test_discovery_ms",
+        record.time_to_first_test_discovery_ms,
+    );
+    a.opt_int(
+        "time_to_first_test_run_ms",
+        record.time_to_first_test_run_ms,
+    );
+    a.opt_int(
+        "time_to_first_pass_test_result_ms",
+        record.time_to_first_pass_test_result_ms,
+    );
+    a.opt_int(
+        "time_to_first_fail_test_result_ms",
+        record.time_to_first_fail_test_result_ms,
+    );
+    a.opt_int(
+        "time_to_first_fatal_test_result_ms",
+        record.time_to_first_fatal_test_result_ms,
+    );
+    a.opt_int(
+        "time_to_first_timeout_test_result_ms",
+        record.time_to_first_timeout_test_result_ms,
+    );
+    a.opt_int(
+        "time_to_first_skip_test_result_ms",
+        record.time_to_first_skip_test_result_ms,
+    );
+    a.opt_int(
+        "time_to_first_unknown_test_result_ms",
+        record.time_to_first_unknown_test_result_ms,
+    );
+    a.opt_int(
+        "time_to_first_infra_failure_test_result_ms",
+        record.time_to_first_infra_failure_test_result_ms,
+    );
+    a.int("exec_time_ms", record.exec_time_ms);
+
+    // -- Memory / system ---------------------------------------------------------------------
+    a.opt_int("max_malloc_bytes_active", record.max_malloc_bytes_active);
+    a.opt_int(
+        "max_malloc_bytes_allocated",
+        record.max_malloc_bytes_allocated,
+    );
+    a.opt_int(
+        "system_total_memory_bytes",
+        record.system_total_memory_bytes,
+    );
+    a.opt_int(
+        "peak_process_memory_bytes",
+        record.peak_process_memory_bytes,
+    );
+    a.opt_int(
+        "peak_used_disk_space_bytes",
+        record.peak_used_disk_space_bytes,
+    );
+    a.opt_int("total_disk_space_bytes", record.total_disk_space_bytes);
+    a.opt_int("memory_max_anon_allprocs", record.memory_max_anon_allprocs);
+    a.opt_int(
+        "memory_max_anon_forkserver_actions",
+        record.memory_max_anon_forkserver_actions,
+    );
+    a.opt_int(
+        "memory_max_total_allprocs",
+        record.memory_max_total_allprocs,
+    );
+    a.opt_int(
+        "memory_max_total_forkserver_actions",
+        record.memory_max_total_forkserver_actions,
+    );
+
+    // -- DICE / in-progress peaks ------------------------------------------------------------
+    a.opt_int(
+        "max_dice_in_progress_keys",
+        record.max_dice_in_progress_keys,
+    );
+    a.opt_int("max_dice_compute_keys", record.max_dice_compute_keys);
+    a.opt_int("max_in_progress_actions", record.max_in_progress_actions);
+    a.opt_int(
+        "max_in_progress_local_actions",
+        record.max_in_progress_local_actions,
+    );
+    a.opt_int(
+        "max_in_progress_remote_actions",
+        record.max_in_progress_remote_actions,
+    );
+    a.opt_int(
+        "max_in_progress_remote_uploads",
+        record.max_in_progress_remote_uploads,
+    );
+
+    // -- Remote execution bytes / speeds -----------------------------------------------------
+    a.opt_int("re_upload_bytes", record.re_upload_bytes);
+    a.opt_int("re_download_bytes", record.re_download_bytes);
+    a.opt_int("re_max_download_speed", record.re_max_download_speed);
+    a.opt_int("re_max_upload_speed", record.re_max_upload_speed);
+    a.opt_int("re_avg_download_speed", record.re_avg_download_speed);
+    a.opt_int("re_avg_upload_speed", record.re_avg_upload_speed);
+    a.opt_float(
+        "re_average_local_cache_lookup_microseconds",
+        record.re_average_local_cache_lookup_microseconds,
+    );
+
+    // -- Local cache -------------------------------------------------------------------------
+    a.opt_int("local_cache_hits_files", record.local_cache_hits_files);
+    a.opt_int("local_cache_hits_bytes", record.local_cache_hits_bytes);
+    a.opt_int("local_cache_misses_files", record.local_cache_misses_files);
+    a.opt_int("local_cache_misses_bytes", record.local_cache_misses_bytes);
+    a.opt_int(
+        "local_cache_hits_files_from_memory_cache",
+        record.local_cache_hits_files_from_memory_cache,
+    );
+    a.opt_int(
+        "local_cache_hits_files_from_filesystem_cache",
+        record.local_cache_hits_files_from_filesystem_cache,
+    );
+    a.opt_int("local_cache_lookups", record.local_cache_lookups);
+
+    // -- Storage backends (zdb / zgateway / manifold / hedwig) -------------------------------
+    a.opt_int("zdb_download_queries", record.zdb_download_queries);
+    a.opt_int("zdb_download_bytes", record.zdb_download_bytes);
+    a.opt_int("zdb_upload_queries", record.zdb_upload_queries);
+    a.opt_int("zdb_upload_bytes", record.zdb_upload_bytes);
+    a.opt_int(
+        "zgateway_download_queries",
+        record.zgateway_download_queries,
+    );
+    a.opt_int("zgateway_download_bytes", record.zgateway_download_bytes);
+    a.opt_int("zgateway_upload_queries", record.zgateway_upload_queries);
+    a.opt_int("zgateway_upload_bytes", record.zgateway_upload_bytes);
+    a.opt_int(
+        "manifold_download_queries",
+        record.manifold_download_queries,
+    );
+    a.opt_int("manifold_download_bytes", record.manifold_download_bytes);
+    a.opt_int("manifold_upload_queries", record.manifold_upload_queries);
+    a.opt_int("manifold_upload_bytes", record.manifold_upload_bytes);
+    a.opt_int("hedwig_download_queries", record.hedwig_download_queries);
+    a.opt_int("hedwig_download_bytes", record.hedwig_download_bytes);
+    a.opt_int("hedwig_upload_queries", record.hedwig_upload_queries);
+    a.opt_int("hedwig_upload_bytes", record.hedwig_upload_bytes);
+
+    // -- Event sink --------------------------------------------------------------------------
+    a.opt_int("sink_success_count", record.sink_success_count);
+    a.opt_int("sink_failure_count", record.sink_failure_count);
+    a.opt_int("sink_dropped_count", record.sink_dropped_count);
+    a.opt_int("sink_bytes_written", record.sink_bytes_written);
+    a.opt_int("sink_max_buffer_depth", record.sink_max_buffer_depth);
+
+    // -- IO syscall counts -------------------------------------------------------------------
+    a.opt_int("io_copy_count", record.io_copy_count);
+    a.opt_int("io_symlink_count", record.io_symlink_count);
+    a.opt_int("io_hardlink_count", record.io_hardlink_count);
+    a.opt_int("io_mkdir_count", record.io_mkdir_count);
+    a.opt_int("io_readdir_count", record.io_readdir_count);
+    a.opt_int("io_readdir_eden_count", record.io_readdir_eden_count);
+    a.opt_int("io_rmdir_count", record.io_rmdir_count);
+    a.opt_int("io_rmdir_all_count", record.io_rmdir_all_count);
+    a.opt_int("io_stat_count", record.io_stat_count);
+    a.opt_int("io_stat_eden_count", record.io_stat_eden_count);
+    a.opt_int("io_chmod_count", record.io_chmod_count);
+    a.opt_int("io_readlink_count", record.io_readlink_count);
+    a.opt_int("io_remove_count", record.io_remove_count);
+    a.opt_int("io_rename_count", record.io_rename_count);
+    a.opt_int("io_read_count", record.io_read_count);
+    a.opt_int("io_write_count", record.io_write_count);
+    a.opt_int("io_canonicalize_count", record.io_canonicalize_count);
+    a.opt_int("io_eden_settle_count", record.io_eden_settle_count);
+
+    // -- Versions / environment --------------------------------------------------------------
+    a.opt_string("watchman_version", record.watchman_version.clone());
+    a.opt_string("eden_version", record.eden_version.clone());
+    a.opt_string("file_watcher", record.file_watcher.clone());
+    a.opt_string(
+        "persistent_cache_mode",
+        record.persistent_cache_mode.clone(),
+    );
+    a.opt_int("file_watcher_duration_ms", record.file_watcher_duration_ms);
+    a.opt_int(
+        "initial_materializer_entries_from_sqlite",
+        record.initial_materializer_entries_from_sqlite,
+    );
+
+    // -- Source control ----------------------------------------------------------------------
+    // A repo is either hg or git, so at most one of these is set; both map to the same OTel
+    // `vcs.ref.head.revision` (the current checkout's revision).
+    a.opt_string_std(VCS_REF_HEAD_REVISION, record.hg_revision.clone());
+    a.opt_string_std(VCS_REF_HEAD_REVISION, record.git_revision.clone());
+    a.opt_bool("has_local_changes", record.has_local_changes);
+    a.strings(
+        "version_control_errors",
+        record.version_control_errors.iter().cloned(),
+    );
+    a.strings(
+        "representative_config_flags",
+        record.representative_config_flags.iter().cloned(),
+    );
+
+    // -- Outcome / status --------------------------------------------------------------------
+    // The process exit status -- OTel `process.exit.code`.
+    a.opt_int_std(PROCESS_EXIT_CODE, record.exit_code);
+    a.opt_string("exit_result_name", record.exit_result_name.clone());
+    a.opt_bool("has_command_result", record.has_command_result);
+    a.opt_bool("has_end_of_stream", record.has_end_of_stream);
+    a.opt_bool(
+        "instant_command_is_success",
+        record.instant_command_is_success,
+    );
+    a.opt_bool(
+        "daemon_connection_failure",
+        record.daemon_connection_failure,
+    );
+    a.opt_bool("should_restart", record.should_restart);
+    a.opt_bool("eligible_for_full_hybrid", record.eligible_for_full_hybrid);
+    a.opt_bool("new_configs_used", record.new_configs_used);
+    a.opt_string(
+        "critical_path_backend",
+        record.critical_path_backend.clone(),
+    );
+    a.opt_int(
+        "compressed_event_log_size_bytes",
+        record.compressed_event_log_size_bytes,
+    );
+    a.opt_int("event_log_manifold_ttl_s", record.event_log_manifold_ttl_s);
+    a.opt_int("wrapper_start_time", record.wrapper_start_time);
+    a.opt_string("installer_log_url", record.installer_log_url.clone());
+
+    // -- Enums (stored as i32; emit the proto enum name) -------------------------------------
+    if let Some(outcome) = record
+        .outcome
+        .and_then(|v| buck2_data::InvocationOutcome::try_from(v).ok())
+    {
+        a.string("outcome", outcome.as_str_name());
+    }
+    if let Some(reason) = record
+        .daemon_was_started
+        .and_then(|v| buck2_data::DaemonWasStartedReason::try_from(v).ok())
+    {
+        a.string("daemon_was_started", reason.as_str_name());
+    }
+    a.strings(
+        "active_networks_kinds",
+        record
+            .active_networks_kinds
+            .iter()
+            .filter_map(|&v| buck2_data::NetworkKind::try_from(v).ok())
+            .map(|k| k.as_str_name()),
+    );
+
+    // -- Resolved target patterns (unwrap the single-field `TargetPattern` wrapper) ----------
+    if let Some(patterns) = &record.parsed_target_patterns {
+        a.strings(
+            "parsed_target_patterns",
+            patterns.target_patterns.iter().map(|p| p.value.clone()),
+        );
+    }
+
+    // -- Dynamic key-value maps: each entry's key becomes its own attribute key ---------------
+    // `metadata` is the explicit Scuba passthrough; `client_metadata` and `install_device_metadata`
+    // are likewise lists of (key, value) pairs, so we emit `<map>.<entry_key>` rather than two
+    // parallel `.key`/`.value` arrays (which can't be correlated by a backend). These keys are
+    // dynamic and not guaranteed unique across entries, so the final dedup pass (last-wins) resolves
+    // any collisions.
+    if let Some(metadata) = &record.metadata {
+        for (k, v) in &metadata.strings {
+            a.push(format!("metadata.{k}"), v.clone());
+        }
+        for (k, v) in &metadata.ints {
+            a.push(format!("metadata.{k}"), *v);
+        }
+    }
+    for m in &record.client_metadata {
+        a.push(format!("client_metadata.{}", m.key), m.value.clone());
+    }
+    for entry in record
+        .install_device_metadata
+        .iter()
+        .flat_map(|d| d.entry.iter())
+    {
+        a.push(
+            format!("install_device_metadata.{}", entry.key),
+            entry.value.clone(),
+        );
+    }
+
+    // -- Repeated messages projected field-wise into parallel arrays -------------------------
+    a.strings(
+        "soft_error_categories.category",
+        record
+            .soft_error_categories
+            .iter()
+            .map(|e| e.category.clone()),
+    );
+    a.bools(
+        "soft_error_categories.is_quiet",
+        record.soft_error_categories.iter().map(|e| e.is_quiet),
+    );
+
+    a.strings(
+        "errors.message",
+        record.errors.iter().map(|e| e.message.clone()),
+    );
+    a.strings(
+        "errors.category",
+        record.errors.iter().filter_map(|e| e.category.clone()),
+    );
+    a.strings(
+        "errors.category_key",
+        record.errors.iter().filter_map(|e| e.category_key.clone()),
+    );
+    a.strings(
+        "errors.best_tag",
+        record.errors.iter().filter_map(|e| e.best_tag.clone()),
+    );
+    a.strings(
+        "errors.source_area",
+        record.errors.iter().filter_map(|e| e.source_area.clone()),
+    );
+    a.strings(
+        "errors.source_location",
+        record
+            .errors
+            .iter()
+            .filter_map(|e| e.source_location.clone()),
+    );
+    a.strings(
+        "errors.telemetry_message",
+        record
+            .errors
+            .iter()
+            .filter_map(|e| e.telemetry_message.clone()),
+    );
+    a.strings(
+        "errors.tags",
+        record.errors.iter().flat_map(|e| e.tags.iter().cloned()),
+    );
+    a.strings(
+        "errors.sub_error_categories",
+        record
+            .errors
+            .iter()
+            .flat_map(|e| e.sub_error_categories.iter().cloned()),
+    );
+
+    // -- Nested sub-messages -----------------------------------------------------------------
+    if let Some(snapshot) = &record.first_snapshot {
+        push_snapshot(&mut a, "first_snapshot", snapshot);
+    }
+    if let Some(snapshot) = &record.last_snapshot {
+        push_snapshot(&mut a, "last_snapshot", snapshot);
+    }
+    if let Some(command_end) = &record.command_end {
+        push_command_end(&mut a, command_end);
+    }
+    if let Some(stats) = &record.file_watcher_stats {
+        push_file_watcher_stats(&mut a, stats);
+    }
+    if let Some(options) = &record.command_options {
+        push_command_options(&mut a, options);
+    }
+    if let Some(target_cfg) = &record.target_cfg {
+        push_target_cfg(&mut a, target_cfg);
+    }
+    if let Some(revision) = &record.version_control_revision {
+        push_version_control_revision(&mut a, revision);
+    }
+
+    a.into_attrs()
+}
+
+fn push_command_options(a: &mut Attrs, o: &buck2_data::CommandOptions) {
+    a.int(
+        "command_options.configured_parallelism",
+        o.configured_parallelism,
+    );
+    a.int(
+        "command_options.available_parallelism",
+        o.available_parallelism,
+    );
+}
+
+fn push_target_cfg(a: &mut Attrs, t: &buck2_data::TargetCfg) {
+    a.strings(
+        "target_cfg.target_platforms",
+        t.target_platforms.iter().cloned(),
+    );
+    a.strings("target_cfg.cli_modifiers", t.cli_modifiers.iter().cloned());
+}
+
+fn push_version_control_revision(a: &mut Attrs, r: &buck2_data::VersionControlRevision) {
+    a.opt_string(
+        "version_control_revision.hg_revision",
+        r.hg_revision.clone(),
+    );
+    a.opt_string(
+        "version_control_revision.git_revision",
+        r.git_revision.clone(),
+    );
+    a.opt_bool(
+        "version_control_revision.has_local_changes",
+        r.has_local_changes,
+    );
+    a.opt_string(
+        "version_control_revision.command_error",
+        r.command_error.clone(),
+    );
+}
+
+fn push_file_watcher_stats(a: &mut Attrs, s: &buck2_data::FileWatcherStats) {
+    a.bool("file_watcher_stats.fresh_instance", s.fresh_instance);
+    a.int("file_watcher_stats.events_total", s.events_total);
+    a.int("file_watcher_stats.events_processed", s.events_processed);
+    // The mergebase the working copy branched from -- OTel `vcs.ref.base.revision`.
+    a.opt_string_std(VCS_REF_BASE_REVISION, s.branched_from_revision.clone());
+    a.opt_int(
+        "file_watcher_stats.branched_from_global_rev",
+        s.branched_from_global_rev,
+    );
+    a.opt_string(
+        "file_watcher_stats.incomplete_events_reason",
+        s.incomplete_events_reason.clone(),
+    );
+    a.opt_string(
+        "file_watcher_stats.watchman_version",
+        s.watchman_version.clone(),
+    );
+    a.opt_int(
+        "file_watcher_stats.branched_from_revision_timestamp",
+        s.branched_from_revision_timestamp,
+    );
+    a.opt_string("file_watcher_stats.eden_version", s.eden_version.clone());
+
+    // `events` is a repeated message: project field-wise into parallel arrays.
+    a.strings(
+        "file_watcher_stats.events.path",
+        s.events.iter().map(|e| e.path.clone()),
+    );
+    a.strings(
+        "file_watcher_stats.events.event",
+        s.events
+            .iter()
+            .filter_map(|e| buck2_data::FileWatcherEventType::try_from(e.event).ok())
+            .map(|e| e.as_str_name()),
+    );
+    a.strings(
+        "file_watcher_stats.events.kind",
+        s.events
+            .iter()
+            .filter_map(|e| buck2_data::FileWatcherKind::try_from(e.kind).ok())
+            .map(|e| e.as_str_name()),
+    );
+
+    if let Some(fresh) = &s.fresh_instance_data {
+        a.bool(
+            "file_watcher_stats.fresh_instance_data.new_mergebase",
+            fresh.new_mergebase,
+        );
+        a.bool(
+            "file_watcher_stats.fresh_instance_data.cleared_dice",
+            fresh.cleared_dice,
+        );
+        a.bool(
+            "file_watcher_stats.fresh_instance_data.cleared_dep_files",
+            fresh.cleared_dep_files,
+        );
+    }
+}
+
+fn push_snapshot(a: &mut Attrs, prefix: &str, s: &buck2_data::Snapshot) {
+    let k = |n: &str| format!("{prefix}.{n}");
+
+    a.opt_int(k("buck2_rss"), s.buck2_rss);
+    a.int(k("buck2_max_rss"), s.buck2_max_rss);
+    a.int(k("buck2_user_cpu_us"), s.buck2_user_cpu_us);
+    a.int(k("buck2_system_cpu_us"), s.buck2_system_cpu_us);
+    a.int(
+        k("blocking_executor_io_queue_size"),
+        s.blocking_executor_io_queue_size,
+    );
+    a.int(
+        k("tokio_blocking_queue_depth"),
+        s.tokio_blocking_queue_depth,
+    );
+    a.int(
+        k("tokio_num_idle_blocking_threads"),
+        s.tokio_num_idle_blocking_threads,
+    );
+    a.int(
+        k("tokio_num_blocking_threads"),
+        s.tokio_num_blocking_threads,
+    );
+    a.int(k("allprocs_memory_pressure"), s.allprocs_memory_pressure);
+
+    a.int(k("re_download_bytes"), s.re_download_bytes);
+    a.int(k("re_upload_bytes"), s.re_upload_bytes);
+    a.int(k("re_uploads_started"), s.re_uploads_started);
+    a.int(
+        k("re_uploads_finished_successfully"),
+        s.re_uploads_finished_successfully,
+    );
+    a.int(
+        k("re_uploads_finished_with_error"),
+        s.re_uploads_finished_with_error,
+    );
+    a.int(k("re_downloads_started"), s.re_downloads_started);
+    a.int(
+        k("re_downloads_finished_successfully"),
+        s.re_downloads_finished_successfully,
+    );
+    a.int(
+        k("re_downloads_finished_with_error"),
+        s.re_downloads_finished_with_error,
+    );
+    a.int(k("re_action_cache_started"), s.re_action_cache_started);
+    a.int(
+        k("re_action_cache_finished_successfully"),
+        s.re_action_cache_finished_successfully,
+    );
+    a.int(
+        k("re_action_cache_finished_with_error"),
+        s.re_action_cache_finished_with_error,
+    );
+    a.int(k("re_executes_started"), s.re_executes_started);
+    a.int(
+        k("re_executes_finished_successfully"),
+        s.re_executes_finished_successfully,
+    );
+    a.int(
+        k("re_executes_finished_with_error"),
+        s.re_executes_finished_with_error,
+    );
+    a.int(k("re_materializes_started"), s.re_materializes_started);
+    a.int(
+        k("re_materializes_finished_successfully"),
+        s.re_materializes_finished_successfully,
+    );
+    a.int(
+        k("re_materializes_finished_with_error"),
+        s.re_materializes_finished_with_error,
+    );
+    a.int(
+        k("re_write_action_results_started"),
+        s.re_write_action_results_started,
+    );
+    a.int(
+        k("re_write_action_results_finished_successfully"),
+        s.re_write_action_results_finished_successfully,
+    );
+    a.int(
+        k("re_write_action_results_finished_with_error"),
+        s.re_write_action_results_finished_with_error,
+    );
+    a.int(
+        k("re_get_digest_expirations_started"),
+        s.re_get_digest_expirations_started,
+    );
+    a.int(
+        k("re_get_digest_expirations_finished_successfully"),
+        s.re_get_digest_expirations_finished_successfully,
+    );
+    a.int(
+        k("re_get_digest_expirations_finished_with_error"),
+        s.re_get_digest_expirations_finished_with_error,
+    );
+
+    a.int(k("io_in_flight_copy"), s.io_in_flight_copy);
+    a.int(k("io_in_flight_symlink"), s.io_in_flight_symlink);
+    a.int(k("io_in_flight_hardlink"), s.io_in_flight_hardlink);
+    a.int(k("io_in_flight_mk_dir"), s.io_in_flight_mk_dir);
+    a.int(k("io_in_flight_read_dir"), s.io_in_flight_read_dir);
+    a.int(
+        k("io_in_flight_read_dir_eden"),
+        s.io_in_flight_read_dir_eden,
+    );
+    a.int(k("io_in_flight_rm_dir"), s.io_in_flight_rm_dir);
+    a.int(k("io_in_flight_rm_dir_all"), s.io_in_flight_rm_dir_all);
+    a.int(k("io_in_flight_stat"), s.io_in_flight_stat);
+    a.int(k("io_in_flight_stat_eden"), s.io_in_flight_stat_eden);
+    a.int(k("io_in_flight_chmod"), s.io_in_flight_chmod);
+    a.int(k("io_in_flight_read_link"), s.io_in_flight_read_link);
+    a.int(k("io_in_flight_remove"), s.io_in_flight_remove);
+    a.int(k("io_in_flight_rename"), s.io_in_flight_rename);
+    a.int(k("io_in_flight_read"), s.io_in_flight_read);
+    a.int(k("io_in_flight_write"), s.io_in_flight_write);
+    a.int(k("io_in_flight_canonicalize"), s.io_in_flight_canonicalize);
+    a.int(k("io_in_flight_eden_settle"), s.io_in_flight_eden_settle);
+
+    a.int(k("daemon_uptime_s"), s.daemon_uptime_s);
+
+    a.opt_int(k("malloc_bytes_active"), s.malloc_bytes_active);
+    a.opt_int(k("malloc_bytes_allocated"), s.malloc_bytes_allocated);
+    a.opt_int(k("used_disk_space_bytes"), s.used_disk_space_bytes);
+
+    a.opt_int(k("host_cpu_usage_system_ms"), s.host_cpu_usage_system_ms);
+    a.opt_int(k("host_cpu_usage_user_ms"), s.host_cpu_usage_user_ms);
+
+    a.int(k("dice_key_count"), s.dice_key_count);
+    a.int(
+        k("dice_currently_active_key_count"),
+        s.dice_currently_active_key_count,
+    );
+    a.int(
+        k("dice_active_transaction_count"),
+        s.dice_active_transaction_count,
+    );
+
+    a.int(
+        k("deferred_materializer_queue_size"),
+        s.deferred_materializer_queue_size,
+    );
+
+    a.opt_int(k("sink_successes"), s.sink_successes);
+    a.opt_int(k("sink_failures"), s.sink_failures);
+    a.opt_int(
+        k("sink_failures_invalid_request"),
+        s.sink_failures_invalid_request,
+    );
+    a.opt_int(
+        k("sink_failures_unauthorized"),
+        s.sink_failures_unauthorized,
+    );
+    a.opt_int(
+        k("sink_failures_rate_limited"),
+        s.sink_failures_rate_limited,
+    );
+    a.opt_int(k("sink_failures_pushed_back"), s.sink_failures_pushed_back);
+    a.opt_int(
+        k("sink_failures_enqueue_failed"),
+        s.sink_failures_enqueue_failed,
+    );
+    a.opt_int(
+        k("sink_failures_internal_error"),
+        s.sink_failures_internal_error,
+    );
+    a.opt_int(k("sink_failures_timed_out"), s.sink_failures_timed_out);
+    a.opt_int(k("sink_failures_unknown"), s.sink_failures_unknown);
+    a.opt_int(k("sink_buffer_depth"), s.sink_buffer_depth);
+    a.opt_int(k("sink_dropped"), s.sink_dropped);
+    a.opt_int(k("sink_bytes_written"), s.sink_bytes_written);
+
+    // `network_interface_stats` is a map keyed by interface name; emit each interface's counters
+    // under its own dynamic key (like `metadata`).
+    for (interface, stats) in &s.network_interface_stats {
+        a.int(
+            format!("{prefix}.network_interface_stats.{interface}.tx_bytes"),
+            stats.tx_bytes,
+        );
+        a.int(
+            format!("{prefix}.network_interface_stats.{interface}.rx_bytes"),
+            stats.rx_bytes,
+        );
+        if let Ok(network_kind) = buck2_data::NetworkKind::try_from(stats.network_kind) {
+            a.string(
+                format!("{prefix}.network_interface_stats.{interface}.network_kind"),
+                network_kind.as_str_name(),
+            );
+        }
+    }
+
+    a.int(k("http_download_bytes"), s.http_download_bytes);
+
+    a.int(
+        k("deferred_materializer_declares"),
+        s.deferred_materializer_declares,
+    );
+    a.int(
+        k("deferred_materializer_declares_reused"),
+        s.deferred_materializer_declares_reused,
+    );
+
+    if let Some(unix) = &s.unix_system_stats {
+        a.float(k("unix_system_stats.load1"), unix.load1);
+        a.float(k("unix_system_stats.load5"), unix.load5);
+        a.float(k("unix_system_stats.load15"), unix.load15);
+    }
+
+    a.int(k("zdb_download_queries"), s.zdb_download_queries);
+    a.int(k("zdb_download_bytes"), s.zdb_download_bytes);
+    a.int(k("zdb_upload_queries"), s.zdb_upload_queries);
+    a.int(k("zdb_upload_bytes"), s.zdb_upload_bytes);
+
+    a.int(k("zgateway_download_queries"), s.zgateway_download_queries);
+    a.int(k("zgateway_download_bytes"), s.zgateway_download_bytes);
+    a.int(k("zgateway_upload_queries"), s.zgateway_upload_queries);
+    a.int(k("zgateway_upload_bytes"), s.zgateway_upload_bytes);
+
+    a.int(k("manifold_download_queries"), s.manifold_download_queries);
+    a.int(k("manifold_download_bytes"), s.manifold_download_bytes);
+    a.int(k("manifold_upload_queries"), s.manifold_upload_queries);
+    a.int(k("manifold_upload_bytes"), s.manifold_upload_bytes);
+
+    a.int(k("hedwig_download_queries"), s.hedwig_download_queries);
+    a.int(k("hedwig_download_bytes"), s.hedwig_download_bytes);
+    a.int(k("hedwig_upload_queries"), s.hedwig_upload_queries);
+    a.int(k("hedwig_upload_bytes"), s.hedwig_upload_bytes);
+
+    a.int(k("local_cache_hits_files"), s.local_cache_hits_files);
+    a.int(k("local_cache_hits_bytes"), s.local_cache_hits_bytes);
+    a.int(k("local_cache_misses_files"), s.local_cache_misses_files);
+    a.int(k("local_cache_misses_bytes"), s.local_cache_misses_bytes);
+
+    a.int(
+        k("local_cache_hits_files_from_memory_cache"),
+        s.local_cache_hits_files_from_memory_cache,
+    );
+    a.int(
+        k("local_cache_hits_files_from_filesystem_cache"),
+        s.local_cache_hits_files_from_filesystem_cache,
+    );
+
+    a.int(k("local_cache_lookups"), s.local_cache_lookups);
+    a.int(
+        k("local_cache_lookup_latency_microseconds"),
+        s.local_cache_lookup_latency_microseconds,
+    );
+
+    a.opt_int(
+        k("this_event_client_delay_ms"),
+        s.this_event_client_delay_ms,
+    );
+    a.opt_int(k("client_cpu_percents"), s.client_cpu_percents);
+
+    if let Some(cgroup) = &s.allprocs_cgroup {
+        push_cgroup_memory_stats(a, &k("allprocs_cgroup"), cgroup);
+    }
+    if let Some(cgroup) = &s.forkserver_actions_cgroup {
+        push_cgroup_memory_stats(a, &k("forkserver_actions_cgroup"), cgroup);
+    }
+}
+
+fn push_cgroup_memory_stats(a: &mut Attrs, prefix: &str, s: &buck2_data::UnixCgroupMemoryStats) {
+    a.int(format!("{prefix}.anon"), s.anon);
+    a.int(format!("{prefix}.file"), s.file);
+    a.int(format!("{prefix}.kernel"), s.kernel);
+}
+
+fn push_command_end(a: &mut Attrs, c: &buck2_data::CommandEnd) {
+    a.bool("command_end.is_success", c.is_success);
+    if let Some(build_result) = &c.build_result {
+        a.bool(
+            "command_end.build_result.build_completed",
+            build_result.build_completed,
+        );
+    }
+    match &c.data {
+        Some(buck2_data::command_end::Data::Build(e)) => {
+            a.string("command_end.kind", "build");
+            push_build_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Targets(e)) => {
+            a.string("command_end.kind", "targets");
+            push_targets_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Query(e)) => {
+            a.string("command_end.kind", "query");
+            push_query_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Cquery(e)) => {
+            a.string("command_end.kind", "cquery");
+            push_cquery_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Test(e)) => {
+            a.string("command_end.kind", "test");
+            push_test_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Audit(e)) => {
+            a.string("command_end.kind", "audit");
+            push_audit_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Docs(e)) => {
+            a.string("command_end.kind", "docs");
+            push_docs_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Clean(e)) => {
+            a.string("command_end.kind", "clean");
+            push_clean_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Aquery(e)) => {
+            a.string("command_end.kind", "aquery");
+            push_aquery_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Install(e)) => {
+            a.string("command_end.kind", "install");
+            push_install_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Materialize(e)) => {
+            a.string("command_end.kind", "materialize");
+            push_materialize_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Profile(e)) => {
+            a.string("command_end.kind", "profile");
+            push_profile_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Bxl(e)) => {
+            a.string("command_end.kind", "bxl");
+            push_bxl_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Lsp(e)) => {
+            a.string("command_end.kind", "lsp");
+            push_lsp_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::FileStatus(e)) => {
+            a.string("command_end.kind", "file_status");
+            push_file_status_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Starlark(e)) => {
+            a.string("command_end.kind", "starlark");
+            push_starlark_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Subscribe(e)) => {
+            a.string("command_end.kind", "subscribe");
+            push_subscription_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Trace(e)) => {
+            a.string("command_end.kind", "trace");
+            push_trace_io_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Ctargets(e)) => {
+            a.string("command_end.kind", "ctargets");
+            push_configured_targets_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::StarlarkDebugAttach(e)) => {
+            a.string("command_end.kind", "starlark_debug_attach");
+            push_starlark_debug_attach_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Explain(e)) => {
+            a.string("command_end.kind", "explain");
+            push_explain_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::ExpandExternalCell(e)) => {
+            a.string("command_end.kind", "expand_external_cell");
+            push_expand_external_cells_command_end(a, e);
+        }
+        Some(buck2_data::command_end::Data::Complete(e)) => {
+            a.string("command_end.kind", "complete");
+            push_complete_command_end(a, e);
+        }
+        None => {}
+    }
+}
+
+fn push_build_command_end(a: &mut Attrs, e: &buck2_data::BuildCommandEnd) {
+    a.strings(
+        "command_end.build.unresolved_target_patterns",
+        e.unresolved_target_patterns.iter().map(|p| p.value.clone()),
+    );
+}
+
+fn push_targets_command_end(a: &mut Attrs, e: &buck2_data::TargetsCommandEnd) {
+    a.strings(
+        "command_end.targets.unresolved_target_patterns",
+        e.unresolved_target_patterns.iter().map(|p| p.value.clone()),
+    );
+}
+
+fn push_query_command_end(_a: &mut Attrs, _e: &buck2_data::QueryCommandEnd) {}
+
+fn push_cquery_command_end(_a: &mut Attrs, _e: &buck2_data::CQueryCommandEnd) {}
+
+fn push_test_command_end(a: &mut Attrs, e: &buck2_data::TestCommandEnd) {
+    a.strings(
+        "command_end.test.unresolved_target_patterns",
+        e.unresolved_target_patterns.iter().map(|p| p.value.clone()),
+    );
+}
+
+fn push_audit_command_end(_a: &mut Attrs, _e: &buck2_data::AuditCommandEnd) {}
+
+fn push_docs_command_end(_a: &mut Attrs, _e: &buck2_data::DocsCommandEnd) {}
+
+fn push_clean_command_end(a: &mut Attrs, e: &buck2_data::CleanCommandEnd) {
+    if let Some(s) = &e.clean_stale_stats {
+        a.int(
+            "command_end.clean.clean_stale_stats.stale_artifact_count",
+            s.stale_artifact_count,
+        );
+        a.int(
+            "command_end.clean.clean_stale_stats.stale_bytes",
+            s.stale_bytes,
+        );
+        a.int(
+            "command_end.clean.clean_stale_stats.retained_artifact_count",
+            s.retained_artifact_count,
+        );
+        a.int(
+            "command_end.clean.clean_stale_stats.retained_bytes",
+            s.retained_bytes,
+        );
+        a.int(
+            "command_end.clean.clean_stale_stats.untracked_artifact_count",
+            s.untracked_artifact_count,
+        );
+        a.int(
+            "command_end.clean.clean_stale_stats.untracked_bytes",
+            s.untracked_bytes,
+        );
+        a.int(
+            "command_end.clean.clean_stale_stats.cleaned_artifact_count",
+            s.cleaned_artifact_count,
+        );
+        a.int(
+            "command_end.clean.clean_stale_stats.cleaned_bytes",
+            s.cleaned_bytes,
+        );
+        a.int(
+            "command_end.clean.clean_stale_stats.total_duration_s",
+            s.total_duration_s,
+        );
+        a.int(
+            "command_end.clean.clean_stale_stats.scan_duration_s",
+            s.scan_duration_s,
+        );
+        a.int(
+            "command_end.clean.clean_stale_stats.clean_duration_s",
+            s.clean_duration_s,
+        );
+    }
+}
+
+fn push_aquery_command_end(_a: &mut Attrs, _e: &buck2_data::AqueryCommandEnd) {}
+
+fn push_install_command_end(a: &mut Attrs, e: &buck2_data::InstallCommandEnd) {
+    a.strings(
+        "command_end.install.unresolved_target_patterns",
+        e.unresolved_target_patterns.iter().map(|p| p.value.clone()),
+    );
+}
+
+fn push_materialize_command_end(_a: &mut Attrs, _e: &buck2_data::MaterializeCommandEnd) {}
+
+fn push_profile_command_end(_a: &mut Attrs, _e: &buck2_data::ProfileCommandEnd) {}
+
+fn push_bxl_command_end(a: &mut Attrs, e: &buck2_data::BxlCommandEnd) {
+    a.string("command_end.bxl.bxl_label", e.bxl_label.clone());
+}
+
+fn push_lsp_command_end(_a: &mut Attrs, _e: &buck2_data::LspCommandEnd) {}
+
+fn push_file_status_command_end(_a: &mut Attrs, _e: &buck2_data::FileStatusCommandEnd) {}
+
+fn push_starlark_command_end(_a: &mut Attrs, _e: &buck2_data::StarlarkCommandEnd) {}
+
+fn push_subscription_command_end(_a: &mut Attrs, _e: &buck2_data::SubscriptionCommandEnd) {}
+
+fn push_trace_io_command_end(_a: &mut Attrs, _e: &buck2_data::TraceIoCommandEnd) {}
+
+fn push_configured_targets_command_end(
+    _a: &mut Attrs,
+    _e: &buck2_data::ConfiguredTargetsCommandEnd,
+) {
+}
+
+fn push_starlark_debug_attach_command_end(
+    _a: &mut Attrs,
+    _e: &buck2_data::StarlarkDebugAttachCommandEnd,
+) {
+}
+
+fn push_explain_command_end(_a: &mut Attrs, _e: &buck2_data::ExplainCommandEnd) {}
+
+fn push_expand_external_cells_command_end(
+    _a: &mut Attrs,
+    _e: &buck2_data::ExpandExternalCellsCommandEnd,
+) {
+}
+
+fn push_complete_command_end(_a: &mut Attrs, _e: &buck2_data::CompleteCommandEnd) {}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn find<'a>(attrs: &'a [KeyValue], key: &str) -> Option<&'a Value> {
+        attrs
+            .iter()
+            .find(|kv| kv.key.as_str() == key)
+            .map(|kv| &kv.value)
+    }
+
+    fn string(attrs: &[KeyValue], key: &str) -> Option<String> {
+        match find(attrs, key)? {
+            Value::String(s) => Some(s.as_str().to_owned()),
+            _ => None,
+        }
+    }
+
+    fn int(attrs: &[KeyValue], key: &str) -> Option<i64> {
+        match find(attrs, key)? {
+            Value::I64(i) => Some(*i),
+            _ => None,
+        }
+    }
+
+    fn boolean(attrs: &[KeyValue], key: &str) -> Option<bool> {
+        match find(attrs, key)? {
+            Value::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    fn strings(attrs: &[KeyValue], key: &str) -> Option<Vec<String>> {
+        match find(attrs, key)? {
+            Value::Array(Array::String(v)) => {
+                Some(v.iter().map(|s| s.as_str().to_owned()).collect())
+            }
+            _ => None,
+        }
+    }
+
+    /// Exercises one representative field of each mapping shape: scalars, optionals (set and unset),
+    /// the `_us` duration conversion, repeated scalars, an enum projected to its proto name, a nested
+    /// sub-message prefix, the dynamic `metadata` passthrough, and a repeated message projected
+    /// field-wise into parallel arrays. If the mapping for any of these shapes regresses, one of
+    /// these assertions fails.
+    #[test]
+    fn maps_representative_fields() {
+        let record = buck2_data::InvocationRecord {
+            // Scalar string.
+            re_session_id: "session-123".to_owned(),
+            // Repeated scalar -> single string array.
+            cli_args: vec!["build".to_owned(), "//foo:bar".to_owned()],
+            // Required int.
+            run_local_count: 7,
+            // Optional int, present.
+            run_fallback_count: Some(3),
+            // Optional int, absent -- `run_local_only_count` is left None below.
+            // Duration -> integer microseconds.
+            command_duration: Some(::prost_types::Duration {
+                seconds: 2,
+                nanos: 500_000,
+            }),
+            // Enum stored as i32 -> proto enum name.
+            outcome: Some(buck2_data::InvocationOutcome::Success as i32),
+            // Fields mapped onto OpenTelemetry semantic conventions.
+            exit_code: Some(0),
+            git_revision: Some("deadbeef".to_owned()),
+            // Nested sub-message, emitted under a prefix.
+            first_snapshot: Some(buck2_data::Snapshot {
+                buck2_max_rss: 42,
+                ..Default::default()
+            }),
+            // Nested sub-message carrying a semantic-convention field (`branched_from_revision`).
+            file_watcher_stats: Some(buck2_data::FileWatcherStats {
+                branched_from_revision: Some("cafef00d".to_owned()),
+                ..Default::default()
+            }),
+            // Dynamic passthrough map.
+            metadata: Some(buck2_data::TypedMetadata {
+                strings: HashMap::from([("flavor".to_owned(), "vanilla".to_owned())]),
+                ints: HashMap::from([("answer".to_owned(), 42)]),
+            }),
+            // Repeated message -> parallel field-wise arrays. The second error has no category, so
+            // `errors.category` is shorter than `errors.message` (it filters out the None).
+            errors: vec![
+                buck2_data::ProcessedErrorReport {
+                    message: "boom".to_owned(),
+                    category: Some("INFRA".to_owned()),
+                    ..Default::default()
+                },
+                buck2_data::ProcessedErrorReport {
+                    message: "bad".to_owned(),
+                    category: None,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let attrs = invocation_record_attributes(&record);
+
+        // Static marker so backends can segment this wide event.
+        assert_eq!(
+            string(&attrs, "buck2.event_type").as_deref(),
+            Some("invocation_record")
+        );
+
+        // buck2-specific fields are namespaced under `buck2.`.
+        assert_eq!(
+            string(&attrs, "buck2.re_session_id").as_deref(),
+            Some("session-123")
+        );
+        assert_eq!(int(&attrs, "buck2.run_local_count"), Some(7));
+        assert_eq!(int(&attrs, "buck2.run_fallback_count"), Some(3));
+
+        // Fields that map onto OpenTelemetry semantic conventions use the standardized name and
+        // are *not* `buck2.`-prefixed.
+        assert_eq!(
+            strings(&attrs, PROCESS_COMMAND_ARGS),
+            Some(vec!["build".to_owned(), "//foo:bar".to_owned()])
+        );
+        assert!(find(&attrs, "buck2.cli_args").is_none());
+        assert_eq!(int(&attrs, PROCESS_EXIT_CODE), Some(0));
+        assert_eq!(
+            string(&attrs, VCS_REF_HEAD_REVISION).as_deref(),
+            Some("deadbeef")
+        );
+        assert_eq!(
+            string(&attrs, VCS_REF_BASE_REVISION).as_deref(),
+            Some("cafef00d")
+        );
+
+        // Unset optional fields produce no attribute at all (rather than a zero/empty column).
+        assert!(find(&attrs, "buck2.run_local_only_count").is_none());
+
+        // 2s + 500_000ns = 2_000_000us + 500us.
+        assert_eq!(int(&attrs, "buck2.command_duration_us"), Some(2_000_500));
+
+        assert_eq!(string(&attrs, "buck2.outcome").as_deref(), Some("Success"));
+        assert_eq!(int(&attrs, "buck2.first_snapshot.buck2_max_rss"), Some(42));
+
+        assert_eq!(
+            string(&attrs, "buck2.metadata.flavor").as_deref(),
+            Some("vanilla")
+        );
+        assert_eq!(int(&attrs, "buck2.metadata.answer"), Some(42));
+
+        assert_eq!(
+            strings(&attrs, "buck2.errors.message"),
+            Some(vec!["boom".to_owned(), "bad".to_owned()])
+        );
+        assert_eq!(
+            strings(&attrs, "buck2.errors.category"),
+            Some(vec!["INFRA".to_owned()])
+        );
+    }
+
+    /// Empty repeated fields and absent optionals must not produce attributes -- an empty column
+    /// carries no information and just inflates every event. The default record has nothing set.
+    #[test]
+    fn skips_empty_and_absent_fields() {
+        let attrs = invocation_record_attributes(&buck2_data::InvocationRecord::default());
+
+        // Empty repeated scalar: no array attribute.
+        assert!(find(&attrs, PROCESS_COMMAND_ARGS).is_none());
+        assert!(find(&attrs, "buck2.tags").is_none());
+        // Absent optional duration / enum / nested message.
+        assert!(find(&attrs, "buck2.command_duration_us").is_none());
+        assert!(find(&attrs, "buck2.outcome").is_none());
+        assert!(find(&attrs, "buck2.first_snapshot.buck2_max_rss").is_none());
+
+        // The static marker is unconditional, so it is always present even for an empty record.
+        assert_eq!(
+            string(&attrs, "buck2.event_type").as_deref(),
+            Some("invocation_record")
+        );
+    }
+
+    /// `bool` optionals: present when set, absent when not. (The default-record test covers absence
+    /// of most shapes; bools get their own check because `false` is a meaningful set value that must
+    /// not be confused with "unset".)
+    #[test]
+    fn maps_optional_bools() {
+        let record = buck2_data::InvocationRecord {
+            has_local_changes: Some(false),
+            ..Default::default()
+        };
+        let attrs = invocation_record_attributes(&record);
+        // Explicitly set to `false` -- must be emitted, not skipped.
+        assert_eq!(boolean(&attrs, "buck2.has_local_changes"), Some(false));
+        // Never set -- must be absent.
+        assert!(find(&attrs, "buck2.new_configs_used").is_none());
+    }
+
+    /// `client_metadata` / `install_device_metadata` are key-value maps: each entry's key becomes
+    /// its own attribute (`<map>.<entry_key>`), not parallel `.key`/`.value` arrays. Duplicate keys
+    /// (here, two install devices sharing `os`) are resolved last-wins by the dedup pass.
+    #[test]
+    fn maps_key_value_metadata() {
+        let record = buck2_data::InvocationRecord {
+            client_metadata: vec![buck2_data::ClientMetadata {
+                key: "user".to_owned(),
+                value: "alice".to_owned(),
+            }],
+            install_device_metadata: vec![
+                buck2_data::DeviceMetadata {
+                    entry: vec![buck2_data::device_metadata::Entry {
+                        key: "os".to_owned(),
+                        value: "ios".to_owned(),
+                    }],
+                },
+                buck2_data::DeviceMetadata {
+                    entry: vec![buck2_data::device_metadata::Entry {
+                        key: "os".to_owned(),
+                        value: "android".to_owned(),
+                    }],
+                },
+            ],
+            ..Default::default()
+        };
+        let attrs = invocation_record_attributes(&record);
+
+        // Entry key becomes the attribute key; no parallel `.key`/`.value` arrays.
+        assert_eq!(
+            string(&attrs, "buck2.client_metadata.user").as_deref(),
+            Some("alice")
+        );
+        assert!(find(&attrs, "buck2.client_metadata.key").is_none());
+        assert!(find(&attrs, "buck2.client_metadata.value").is_none());
+
+        // Duplicate key across devices: last write wins, and only one attribute is emitted.
+        assert_eq!(
+            string(&attrs, "buck2.install_device_metadata.os").as_deref(),
+            Some("android")
+        );
+        assert_eq!(
+            attrs
+                .iter()
+                .filter(|kv| kv.key.as_str() == "buck2.install_device_metadata.os")
+                .count(),
+            1
+        );
+    }
+}


### PR DESCRIPTION
This adds a new `OtelEventSink` which sends `InvocationRecord` wide events to an OpenTelemetry collector, if configured.