### PR TITLE
Stop doing a tset projection walk in write_json validation

### DIFF
--- a/app/buck2_build_api/src/actions/impls/json.rs
+++ b/app/buck2_build_api/src/actions/impls/json.rs
@@ -192,7 +192,14 @@ impl<'a, 'v> Serialize for SerializeValue<'a, 'v> {
             }
             JsonUnpack::Enum(x) => x.serialize(serializer),
             JsonUnpack::TransitiveSetJsonProjection(x) => {
-                serializer.collect_seq(err(x.iter_values())?.map(|v| self.with_value(v)))
+                match self.fs {
+                    // Skip validation when fs == None because it can be expensive.
+                    // TransitiveSet::new already did validate_json for projected values.
+                    None => serializer.collect_seq(std::iter::empty::<u8>()),
+                    Some(_) => {
+                        serializer.collect_seq(err(x.iter_values())?.map(|v| self.with_value(v)))
+                    }
+                }
             }
             JsonUnpack::TargetLabel(x) => {
                 // Users could do this with `str(ctx.label.raw_target())`, but in some benchmarks that causes


### PR DESCRIPTION
Unnecessary given validation in TransitiveSet:new.

Already upstreamed.