### PR TITLE
GHA: build-and-test: Don't run on `mercury-head`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,8 @@
 name: Build and test
 on:
   push:
+    branches:
+      - mercury-head
   pull_request:
   workflow_dispatch: # allows manual triggering
 jobs:


### PR DESCRIPTION
Right now we run CI on `pull_request` and `push`, which means it runs twice on PRs. Let's only run it once.