### PR TITLE
remote_execution: Remove `impl Copy for RERuntimeOpts`

### DIFF
--- a/app/buck2_execute/src/re/client.rs
+++ b/app/buck2_execute/src/re/client.rs
@@ -1078,7 +1078,7 @@ impl RemoteExecutionClientImpl {
         /// Wait for either the ExecuteResponse to show up, or a stage change, within a span
         /// on the CommandExecutionManager.
         async fn wait_for_response_or_stage_change(
-            receiver: &mut BoxStream<'static, anyhow::Result<ExecuteWithProgressResponse>>,
+            receiver: &mut BoxStream<'_, anyhow::Result<ExecuteWithProgressResponse>>,
             previous_stage: Stage,
             previous_metadata: &Option<OperationMetadata>,
             report_stage: re_stage::Stage,

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -244,7 +244,7 @@ pub struct RECapabilities {
 }
 
 /// Contains runtime options for the remote execution client as set under `buck2_re_client`
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct RERuntimeOpts {
     /// Use the Meta version of the request metadata
     use_fbcode_metadata: bool,
@@ -798,7 +798,7 @@ impl REClient {
                             ..Default::default()
                         },
                         metadata,
-                        self.runtime_opts,
+                        &self.runtime_opts,
                     ))
                     .await?;
 
@@ -837,7 +837,7 @@ impl REClient {
                             ..Default::default()
                         },
                         metadata,
-                        self.runtime_opts,
+                        &self.runtime_opts,
                     ))
                     .await?;
 
@@ -858,7 +858,7 @@ impl REClient {
         &self,
         metadata: RemoteExecutionMetadata,
         mut execute_request: ExecuteRequest,
-    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<ExecuteWithProgressResponse>>> {
+    ) -> anyhow::Result<BoxStream<'_, anyhow::Result<ExecuteWithProgressResponse>>> {
         // TODO(aloiscochard): Map those properly in the request
         // use crate::proto::build::bazel::remote::execution::v2::ExecutionPolicy;
 
@@ -877,7 +877,7 @@ impl REClient {
         debug!(?metadata, "RE ACTION REQUEST METADATA");
 
         let execution_client = self.grpc_clients.execution_client.clone();
-        let runtime_opts = self.runtime_opts;
+        let runtime_opts = &self.runtime_opts;
 
         // retrying_stream covers both stream establishment and stream reading, so errors like
         // h2 GOAWAY (ENHANCE_YOUR_CALM / "too_many_internal_resets") that surface during
@@ -937,7 +937,6 @@ impl REClient {
             |re_request| async {
                 let metadata = metadata.clone();
                 let cas_client = self.grpc_clients.cas_client.clone();
-                let runtime_opts = self.runtime_opts;
 
                 retry(
                     "BatchUpdateBlobs",
@@ -950,7 +949,7 @@ impl REClient {
                                 .batch_update_blobs(with_re_metadata(
                                     re_request,
                                     metadata,
-                                    runtime_opts,
+                                    &self.runtime_opts,
                                 ))
                                 .await?;
                             Ok(resp.into_inner())
@@ -966,7 +965,6 @@ impl REClient {
             |segments| async {
                 let metadata = metadata.clone();
                 let bytestream_client = self.grpc_clients.bytestream_client.clone();
-                let runtime_opts = self.runtime_opts;
 
                 retry(
                     "BS.write",
@@ -976,7 +974,7 @@ impl REClient {
                         let requests = futures::stream::iter(segments.clone());
                         async move {
                             let resp = bytestream_client
-                                .write(with_re_metadata(requests, metadata, runtime_opts))
+                                .write(with_re_metadata(requests, metadata, &self.runtime_opts))
                                 .await?;
 
                             Ok(resp.into_inner())
@@ -1032,7 +1030,6 @@ impl REClient {
             |re_request| async {
                 let metadata = metadata.clone();
                 let client = self.grpc_clients.cas_client.clone();
-                let runtime_opts = self.runtime_opts;
 
                 retry(
                     "BatchReadBlobs",
@@ -1045,7 +1042,7 @@ impl REClient {
                                 .batch_read_blobs(with_re_metadata(
                                     re_request,
                                     metadata,
-                                    runtime_opts,
+                                    &self.runtime_opts,
                                 ))
                                 .await?
                                 .into_inner())
@@ -1060,7 +1057,6 @@ impl REClient {
             },
             |read_request| {
                 let metadata = metadata.clone();
-                let runtime_opts = self.runtime_opts;
                 async move {
                     let client = self.grpc_clients.bytestream_client.clone();
                     retry(
@@ -1074,7 +1070,7 @@ impl REClient {
                                     .read(with_re_metadata(
                                         read_request,
                                         metadata,
-                                        runtime_opts,
+                                        &self.runtime_opts,
                                     ))
                                     .await?
                                     .into_inner();
@@ -1134,7 +1130,6 @@ impl REClient {
             // Send a request and notify others of the result
             if !digests_to_check.is_empty() {
                 tracing::debug!(num_digests = digests_to_check.len(), "FindMissingBlobs");
-                let runtime_opts = self.runtime_opts;
                 let missing_blobs = retry(
                     "FindMissingBlobs",
                     || {
@@ -1153,7 +1148,7 @@ impl REClient {
                                         ..Default::default()
                                     },
                                     metadata,
-                                    runtime_opts,
+                                    &self.runtime_opts,
                                 ))
                                 .await
                                 .context("Failed to request what blobs are not present on remote")
@@ -1876,7 +1871,7 @@ where
 fn with_re_metadata<T>(
     t: T,
     metadata: RemoteExecutionMetadata,
-    runtime_opts: RERuntimeOpts,
+    runtime_opts: &RERuntimeOpts,
 ) -> tonic::Request<T> {
     // This creates a new Tonic request with attached metadata for the RE
     // backend. There are two cases here we need to support:

--- a/remote_execution/oss/re_grpc/src/retry.rs
+++ b/remote_execution/oss/re_grpc/src/retry.rs
@@ -127,19 +127,19 @@ fn is_retryable(err: &anyhow::Error, retry_not_found: bool) -> Retryable {
 ///
 /// Items from the stream are yielded progressively to the caller (preserving streaming progress
 /// updates), so this is a drop-in replacement for `retry(make_stream) + try_unfold(try_next)`.
-pub fn retrying_stream<F, Fut, S, T>(
+pub fn retrying_stream<'a, F, Fut, S, T>(
     method: &'static str,
     make_stream: F,
     max_retries: usize,
     initial_delay: Duration,
     max_delay: Duration,
     retry_not_found: bool,
-) -> impl Stream<Item = anyhow::Result<T>> + Send + 'static
+) -> impl Stream<Item = anyhow::Result<T>> + Send + 'a
 where
-    F: Fn() -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = anyhow::Result<S>> + Send + 'static,
-    S: futures::TryStream<Ok = T, Error = tonic::Status> + Send + Unpin + 'static,
-    T: Send + 'static,
+    F: Fn() -> Fut + Send + Sync + 'a,
+    Fut: Future<Output = anyhow::Result<S>> + Send + 'a,
+    S: futures::TryStream<Ok = T, Error = tonic::Status> + Send + Unpin + 'a,
+    T: Send + 'a,
 {
     struct RetryState<F, S> {
         make_stream: Arc<F>,


### PR DESCRIPTION
In https://github.com/MercuryTechnologies/buck2/pull/22 I want to store the `RECapabilities` in the `RERuntimeOpts`, which will necessitate either cloning or removing the `Copy` bound.

It turns out we don't need the `Copy` bound at all, but we need to adjust some lifetimes in the users, including adjusting `retrying_stream` to return a `Stream` with a non-`'static` bound (which _can_ be `'static` but can also be tied to the lifetime of a particular value).