### PR TITLE
DUX-5510 re_grpc: zstd-compress large `BatchUpdateBlobs` blobs

### DIFF
--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -450,6 +450,9 @@ pub struct Buck2OssReConfiguration {
     pub max_decoding_message_size: Option<usize>,
     /// The max cumulative blob size for `Read` and `BatchReadBlobs` methods.
     pub max_total_batch_size: Option<usize>,
+    /// Minimum size in bytes of a blob's `data` before it is zstd-compressed in `BatchUpdateBlobs`
+    /// uploads.
+    pub batch_compression_threshold_bytes: Option<usize>,
     /// Maximum number of concurrent upload requests for each action.
     pub max_concurrent_uploads_per_action: Option<usize>,
     /// Time that digests are assumed to live in CAS after being touched.
@@ -562,6 +565,10 @@ impl Buck2OssReConfiguration {
             max_total_batch_size: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "max_total_batch_size",
+            })?,
+            batch_compression_threshold_bytes: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "batch_compression_threshold_bytes",
             })?,
             max_concurrent_uploads_per_action: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -106,6 +106,8 @@ use crate::retry::retrying_stream;
 use crate::stats::CountingConnector;
 
 const DEFAULT_MAX_TOTAL_BATCH_SIZE: usize = 4 * 1000 * 1000;
+/// Default minimum `data` size before a batched blob is zstd-compressed.
+const DEFAULT_BATCH_COMPRESSION_THRESHOLD: usize = 100;
 const INITIAL_DELAY: Duration = Duration::from_millis(100);
 const MAX_DELAY: Duration = Duration::from_secs(10);
 
@@ -242,6 +244,8 @@ pub struct RECapabilities {
     /// Compressors supported by the "compressed-blobs" bytestream resources. Also used to decide
     /// whether we can request zstd-compressed `BatchReadBlobs` responses.
     supported_compressors: Vec<Compressor>,
+    /// Compressors the server accepts for `BatchUpdateBlobs` request `data`.
+    supported_batch_update_compressors: Vec<Compressor>,
 }
 
 /// Contains runtime options for the remote execution client as set under `buck2_re_client`
@@ -258,6 +262,8 @@ pub struct RERuntimeOpts {
     /// Timeout for RPC requests.
     #[expect(unused)]
     rpc_timeout: Duration,
+    /// Minimum `data` size before a batched blob is zstd-compressed in `BatchUpdateBlobs` uploads.
+    batch_compression_threshold: usize,
     /// Whether to request zstd-compressed `BatchReadBlobs` responses (server supports zstd).
     batch_read_zstd: bool,
 }
@@ -309,6 +315,14 @@ impl Compressor {
             Self::Brotli => "brotli",
         }
     }
+}
+
+/// zstd-compress an in-memory blob for a `BatchUpdateBlobs` request.
+async fn zstd_compress_blob(data: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let mut encoder = ZstdEncoder::new(Cursor::new(data));
+    let mut out = Vec::new();
+    encoder.read_to_end(&mut out).await?;
+    Ok(out)
 }
 
 /// Decompress a zstd-compressed blob returned in a `BatchReadBlobs` response.
@@ -413,6 +427,7 @@ impl REClientBuilder {
             RECapabilities {
                 max_total_batch_size: DEFAULT_MAX_TOTAL_BATCH_SIZE,
                 supported_compressors: Vec::new(),
+                supported_batch_update_compressors: Vec::new(),
             }
         };
 
@@ -476,6 +491,9 @@ impl REClientBuilder {
                 cas_ttl_secs: opts.cas_ttl_secs.unwrap_or(60),
                 max_retries: opts.max_retries,
                 rpc_timeout: Duration::from_secs(opts.grpc_timeout),
+                batch_compression_threshold: opts
+                    .batch_compression_threshold_bytes
+                    .unwrap_or(DEFAULT_BATCH_COMPRESSION_THRESHOLD),
                 batch_read_zstd: capabilities
                     .supported_compressors
                     .contains(&Compressor::Zstd),
@@ -513,6 +531,17 @@ impl REClientBuilder {
             Vec::new()
         };
 
+        let supported_batch_update_compressors = if let Some(cache_cap) = &resp.cache_capabilities {
+            cache_cap
+                .supported_batch_update_compressors
+                .iter()
+                .cloned()
+                .filter_map(Compressor::from_grpc)
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         let max_total_batch_size_from_capabilities: Option<usize> =
             if let Some(cache_cap) = resp.cache_capabilities {
                 let size = cache_cap.max_batch_total_size_bytes as usize;
@@ -533,6 +562,7 @@ impl REClientBuilder {
         Ok(RECapabilities {
             max_total_batch_size,
             supported_compressors,
+            supported_batch_update_compressors,
         })
     }
 }
@@ -943,12 +973,20 @@ impl REClient {
         metadata: RemoteExecutionMetadata,
         request: UploadRequest,
     ) -> anyhow::Result<UploadResponse> {
+        // Only compress batched blobs if the server advertised zstd support for BatchUpdateBlobs.
+        let batch_zstd_threshold = self
+            .capabilities
+            .supported_batch_update_compressors
+            .contains(&Compressor::Zstd)
+            .then_some(self.runtime_opts.batch_compression_threshold);
+
         upload_impl(
             &self.instance_name,
             request,
             self.bystream_compressor,
             self.capabilities.max_total_batch_size,
             self.runtime_opts.max_concurrent_uploads_per_action,
+            batch_zstd_threshold,
             |re_request| async {
                 let metadata = metadata.clone();
                 let cas_client = self.grpc_clients.cas_client.clone();
@@ -1692,6 +1730,9 @@ async fn upload_impl<Byt, Cas>(
     bystream_compressor: Option<Compressor>,
     max_total_batch_size: usize,
     max_concurrent_uploads: Option<usize>,
+    // Minimum blob `data` size before zstd-compressing it in a `BatchUpdateBlobs` request.
+    // `None` disables batch compression (e.g. server doesn't advertise zstd support).
+    batch_zstd_threshold: Option<usize>,
     cas_f: impl Fn(BatchUpdateBlobsRequest) -> Cas + Sync + Send + Copy,
     bystream_fut: impl Fn(Vec<WriteRequest>) -> Byt + Sync + Send + Copy,
 ) -> anyhow::Result<UploadResponse>
@@ -1841,14 +1882,8 @@ where
                 ..Default::default()
             };
             for blob in batch {
-                match blob {
-                    BatchUploadRequest::Blob(blob) => {
-                        re_request.requests.push(Request {
-                            digest: Some(tdigest_to(blob.digest.clone())),
-                            data: blob.blob.clone(),
-                            compressor: compressor::Value::Identity as i32,
-                        });
-                    }
+                let (digest, data) = match blob {
+                    BatchUploadRequest::Blob(blob) => (blob.digest.clone(), blob.blob.clone()),
                     BatchUploadRequest::File(file) => {
                         // These should be small files, so no need to use a buffered reader.
                         let mut fin = tokio::fs::File::open(&file.name)
@@ -1856,14 +1891,24 @@ where
                             .with_context(|| format!("Opening {} for writing failed", file.name))?;
                         let mut data = vec![];
                         fin.read_to_end(&mut data).await?;
-
-                        re_request.requests.push(Request {
-                            digest: Some(tdigest_to(file.digest.clone())),
-                            data,
-                            compressor: compressor::Value::Identity as i32,
-                        });
+                        (file.digest.clone(), data)
                     }
-                }
+                };
+
+                // The digest always refers to the *uncompressed* content; only the transmitted
+                // `data` is compressed. Skip small blobs where compression isn't worth it.
+                let (data, compressor) = match batch_zstd_threshold {
+                    Some(threshold) if data.len() > threshold => {
+                        (zstd_compress_blob(&data).await?, compressor::Value::Zstd)
+                    }
+                    _ => (data, compressor::Value::Identity),
+                };
+
+                re_request.requests.push(Request {
+                    digest: Some(tdigest_to(digest)),
+                    data,
+                    compressor: compressor as i32,
+                });
             }
             let blob_hashes = re_request
                 .requests
@@ -2038,8 +2083,60 @@ mod tests {
             cas_ttl_secs: 0,
             max_retries: 0,
             rpc_timeout: Duration::from_secs(60),
+            batch_compression_threshold: DEFAULT_BATCH_COMPRESSION_THRESHOLD,
             batch_read_zstd: false,
         }
+    }
+
+    /// The all-OK response a server would send for a `BatchUpdateBlobs` of these digests.
+    fn batch_update_ok(digests: &[&TDigest]) -> BatchUpdateBlobsResponse {
+        BatchUpdateBlobsResponse {
+            responses: digests
+                .iter()
+                .map(|digest| batch_update_blobs_response::Response {
+                    digest: Some(tdigest_to((*digest).clone())),
+                    status: Some(Status::default()),
+                })
+                .collect(),
+        }
+    }
+
+    /// An upload request inlining the given (hash, blob) pairs, plus the all-OK
+    /// `BatchUpdateBlobs` response the server would send for it.
+    fn inlined_upload(blobs: &[(&str, &[u8])]) -> (UploadRequest, BatchUpdateBlobsResponse) {
+        let digests: Vec<TDigest> = blobs
+            .iter()
+            .map(|&(hash, blob)| TDigest {
+                hash: hash.to_owned(),
+                size_in_bytes: blob.len() as i64,
+                ..Default::default()
+            })
+            .collect();
+        let req = UploadRequest {
+            inlined_blobs_with_digest: Some(
+                digests
+                    .iter()
+                    .zip(blobs)
+                    .map(|(digest, &(_, blob))| InlinedBlobWithDigest {
+                        digest: digest.clone(),
+                        blob: blob.to_vec(),
+                        ..Default::default()
+                    })
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+        let res = batch_update_ok(&digests.iter().collect::<Vec<_>>());
+        (req, res)
+    }
+
+    async fn zstd_decompress(data: &[u8]) -> Vec<u8> {
+        let mut out = vec![];
+        ZstdDecoder::new(Cursor::new(data.to_vec()))
+            .read_to_end(&mut out)
+            .await
+            .unwrap();
+        out
     }
 
     #[tokio::test]
@@ -2627,6 +2724,7 @@ mod tests {
             None,
             10000,
             None,
+            None,
             |req| {
                 let res = res.clone();
                 let digest1 = digest1.clone();
@@ -2637,6 +2735,84 @@ mod tests {
                     assert_eq!(req.requests[0].data, b"aaa");
                     assert_eq!(req.requests[1].digest, Some(tdigest_to(digest2)));
                     assert_eq!(req.requests[1].data, b"bbb");
+                    Ok(res)
+                }
+            },
+            |_req| async { panic!("A Bytestream upload should not be triggered") },
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_batch_upload_zstd_threshold() -> anyhow::Result<()> {
+        // A blob larger than the threshold is zstd-compressed; a small one is left uncompressed.
+        let big = vec![7u8; 1000];
+        let (req, res) = inlined_upload(&[("big", &big), ("small", b"hi")]);
+
+        let expected_big = big.clone();
+        upload_impl(
+            &InstanceName(None),
+            req,
+            None,
+            10000,
+            None,
+            Some(100), // batch zstd threshold
+            |req| {
+                let res = res.clone();
+                let expected_big = expected_big.clone();
+                async move {
+                    let by_hash = |h: &str| {
+                        req.requests
+                            .iter()
+                            .find(|r| r.digest.as_ref().unwrap().hash == h)
+                            .unwrap()
+                            .clone()
+                    };
+
+                    let big_req = by_hash("big");
+                    assert_eq!(big_req.compressor, compressor::Value::Zstd as i32);
+                    // The digest still refers to the uncompressed content...
+                    assert_eq!(big_req.digest.as_ref().unwrap().size_bytes, 1000);
+                    // ...but the transmitted data is the zstd-compressed form.
+                    assert_eq!(zstd_decompress(&big_req.data).await, expected_big);
+
+                    let small_req = by_hash("small");
+                    assert_eq!(small_req.compressor, compressor::Value::Identity as i32);
+                    assert_eq!(small_req.data, b"hi");
+
+                    Ok(res)
+                }
+            },
+            |_req| async { panic!("A Bytestream upload should not be triggered") },
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_batch_upload_zstd_disabled() -> anyhow::Result<()> {
+        // With no threshold (batch compression disabled), everything stays Identity.
+        let big = vec![7u8; 1000];
+        let (req, res) = inlined_upload(&[("big", &big)]);
+
+        upload_impl(
+            &InstanceName(None),
+            req,
+            None,
+            10000,
+            None,
+            None, // batch compression disabled
+            |req| {
+                let res = res.clone();
+                async move {
+                    assert_eq!(
+                        req.requests[0].compressor,
+                        compressor::Value::Identity as i32
+                    );
+                    assert_eq!(req.requests[0].data.len(), 1000);
                     Ok(res)
                 }
             },
@@ -2770,6 +2946,7 @@ mod tests {
             None,
             10, // kept small to simulate a large file upload
             None,
+            None,
             |req| {
                 let res = res.clone();
                 let digest1 = digest1.clone();
@@ -2845,6 +3022,7 @@ mod tests {
             None,
             10, // kept small to simulate a large inlined upload
             None,
+            None,
             |req| {
                 let res = res.clone();
                 let digest1 = digest1.clone();
@@ -2906,6 +3084,7 @@ mod tests {
             req,
             None,
             10,
+            None,
             None,
             |_req| async move {
                 panic!("This should not be called as there are no blobs to upload in batch");
@@ -2969,6 +3148,7 @@ mod tests {
             None,
             3,
             None,
+            None,
             |_req| async move {
                 panic!("Not called");
             },
@@ -3016,6 +3196,7 @@ mod tests {
                     compressor,
                     0, // max_total_batch_size=0 forces bytestream API
                     None,
+                    None,
                     |_req| async move {
                         panic!("Not called");
                     },
@@ -3040,6 +3221,7 @@ mod tests {
                     },
                     compressor,
                     1024, // forces the batch API
+                    None,
                     None,
                     |_req| async move {
                         panic!("Not called");
@@ -3088,6 +3270,7 @@ mod tests {
             None,
             1,
             None,
+            None,
             |_req| async move {
                 panic!("Not called");
             },
@@ -3134,6 +3317,7 @@ mod tests {
             req,
             Some(Compressor::Zstd),
             1,
+            None,
             None,
             |_req| async move {
                 panic!("Not called");
@@ -3203,6 +3387,7 @@ mod tests {
             req,
             Some(Compressor::Zstd),
             1,
+            None,
             None,
             |_req| async move {
                 panic!("Not called");

--- a/remote_execution/oss/re_grpc/src/retry.rs
+++ b/remote_execution/oss/re_grpc/src/retry.rs
@@ -7,13 +7,16 @@
  * of this source tree.
  */
 
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
-use std::future::Future;
+
 use futures::Stream;
 use futures::TryStreamExt;
-use crate::error::{REClientError, TCode};
 use tracing::warn;
+
+use crate::error::REClientError;
+use crate::error::TCode;
 
 pub async fn retry<F, Fut, T>(
     method: &str,
@@ -173,9 +176,7 @@ where
                         {
                             warn!(
                                 "Retrying {} stream open after error: {}. Attempts remaining: {}",
-                                method,
-                                err,
-                                state.retries_left,
+                                method, err, state.retries_left,
                             );
                             tokio::time::sleep(state.delay).await;
                             state.delay *= 2;
@@ -201,9 +202,7 @@ where
                     {
                         warn!(
                             "Retrying {} stream read after error: {}. Attempts remaining: {}",
-                            method,
-                            err,
-                            state.retries_left,
+                            method, err, state.retries_left,
                         );
                         tokio::time::sleep(state.delay).await;
                         state.delay *= 2;


### PR DESCRIPTION
Compress batched blob uploads whose `data` exceeds a configurable threshold (default 100 bytes) with zstd, when the server advertises zstd in its `supported_batch_update_compressors` capability.

It's hard to quantify the benefits of this without getting a packet capture from a CI build, so I'm not going to do that. But given the benefits we saw in #22, it should be a nice bonus.