### PR TITLE
DUX-5607: Re-add tonic patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,13 @@
 [patch.crates-io]
 perf-event = { version = "0.4", git = "https://github.com/Nero5023/perf-event.git", rev = "6dae86b6d4807acec081e6dc0a53167f57f8c0f4" }
 perf-event-open-sys = { version = "5.0", git = "https://github.com/Nero5023/perf-event.git", rev = "6dae86b6d4807acec081e6dc0a53167f57f8c0f4" }
+hyper = { git = "https://github.com/MercuryTechnologies/hyper.git", branch = "jade/push-ktssyytnyrru" }
+tonic = { git = "https://github.com/MercuryTechnologies/grpc-rust.git", branch = "jade/push-rosuyzxnysvw" }
+# unused packages
+# tonic-health = { git = "https://github.com/MercuryTechnologies/grpc-rust.git", branch = "jade/push-rosuyzxnysvw" }
+# tonic-reflection = { git = "https://github.com/MercuryTechnologies/grpc-rust.git", branch = "jade/push-rosuyzxnysvw" }
+tonic-prost = { git = "https://github.com/MercuryTechnologies/grpc-rust.git", branch = "jade/push-rosuyzxnysvw" }
+tonic-prost-build = { git = "https://github.com/MercuryTechnologies/grpc-rust.git", branch = "jade/push-rosuyzxnysvw" }
 
 [profile.release]
 panic = "abort"

--- a/app/buck2_build_signals_impl/src/enhancement.rs
+++ b/app/buck2_build_signals_impl/src/enhancement.rs
@@ -241,7 +241,7 @@ impl CriticalPathProtoEnhancer {
         let duration_proto = duration_to_proto_saturating(duration);
         buck2_data::CriticalPathEntry2 {
             span_ids: Vec::new(),
-            duration: Some(duration_proto.clone()),
+            duration: Some(duration_proto),
             user_duration: Some(prost_types::Duration::default()),
             queue_duration: None,
             total_duration: Some(duration_proto),


### PR DESCRIPTION
Arian correctly pointed out GOAWAY are still broken.

I verified the proposed new buck2 was broken with: https://github.com/arianvp/buck2-grpc-reproducer/blob/fff765fc391ce7e78803fa2a6ce3d028925fd910/run.sh, then that it was fixed by these patches.

Then I rebased these changes. No conflicts, nothing to note.