### PR TITLE
Revert "More semaphores for grpc"

### DIFF
--- a/app/buck2_execute/src/re/client.rs
+++ b/app/buck2_execute/src/re/client.rs
@@ -256,13 +256,6 @@ impl RemoteExecutionClient {
         use_case: RemoteExecutorUseCase,
         platform: &RE::Platform,
     ) -> buck2_error::Result<Option<ActionResultResponse>> {
-        let _permit = self
-            .data
-            .client
-            .grpc_semaphore
-            .acquire()
-            .await
-            .expect("Semaphore should never be closed");
         self.data
             .action_cache
             .op(self
@@ -311,13 +304,6 @@ impl RemoteExecutionClient {
         inlined_blobs_with_digest: Vec<InlinedBlobWithDigest>,
         use_case: RemoteExecutorUseCase,
     ) -> buck2_error::Result<()> {
-        let _permit = self
-            .data
-            .client
-            .grpc_semaphore
-            .acquire()
-            .await
-            .expect("Semaphore should never be closed");
         self.data
             .uploads
             .op(self.data.client.upload_files_and_directories(
@@ -393,13 +379,6 @@ impl RemoteExecutionClient {
         digests: Vec<TDigest>,
         use_case: RemoteExecutorUseCase,
     ) -> buck2_error::Result<Vec<T>> {
-        let _permit = self
-            .data
-            .client
-            .grpc_semaphore
-            .acquire()
-            .await
-            .expect("Semaphore should never be closed");
         self.data
             .downloads
             .op(self
@@ -418,13 +397,6 @@ impl RemoteExecutionClient {
         digest: &TDigest,
         use_case: RemoteExecutorUseCase,
     ) -> buck2_error::Result<Vec<u8>> {
-        let _permit = self
-            .data
-            .client
-            .grpc_semaphore
-            .acquire()
-            .await
-            .expect("Semaphore should never be closed");
         self.data
             .downloads
             .op(self.data.client.download_blob(digest, use_case))
@@ -495,13 +467,6 @@ impl RemoteExecutionClient {
         platform: &RE::Platform,
         write_type: ActionCacheWriteType,
     ) -> buck2_error::Result<WriteActionResultResponse> {
-        let _permit = self
-            .data
-            .client
-            .grpc_semaphore
-            .acquire()
-            .await
-            .expect("Semaphore should never be closed");
         self.data
             .write_action_results
             .op(self
@@ -559,9 +524,6 @@ struct RemoteExecutionClientImpl {
     /// How many files we can be downloading concurrently.
     #[allocative(skip)]
     download_files_semapore: Arc<PrioritySemaphore>,
-    /// Global limit on all concurrent gRPC calls (action cache, downloads, etc)
-    #[allocative(skip)]
-    grpc_semaphore: Arc<Semaphore>,
     /// How many files to kick off downloading concurrently for one request. This should be smaller
     /// than the files semaphore to ensure we can actually *acquire* that semaphore.
     download_chunk_size: usize,
@@ -1067,7 +1029,6 @@ impl RemoteExecutionClientImpl {
                     "buck2-download-priority-sem",
                     download_concurrency,
                 )),
-                grpc_semaphore: Arc::new(Semaphore::new(400)), // TODO: make this configurable
                 download_chunk_size,
                 respect_file_symlinks,
                 persistent_cache_mode,
@@ -1412,24 +1373,15 @@ impl RemoteExecutionClientImpl {
         // 4. We get Ok(0 everywhere), which means it worked
 
         // Obtain a stream of events from RE. If this fails then that is case #1 above so we
-        // bail. The semaphore is held only for the initial gRPC call that establishes the stream,
-        // then released before entering the streaming loop so it doesn't block other calls for
-        // the entire (potentially long) duration of remote execution.
-        let mut receiver = {
-            let _permit = self
-                .grpc_semaphore
-                .acquire()
-                .await
-                .expect("Semaphore should never be closed");
-            self.client()
-                .get_execution_client()
-                .execute_with_progress(metadata, request)
-                // boxed() to segment the future
-                .boxed()
-                .await
-                .map_err(anyhow::Error::from)
-                .context("Failed to start remote execution")?
-        };
+        // bail.
+        let mut receiver = self
+            .client()
+            .get_execution_client()
+            .execute_with_progress(metadata, request)
+            // boxed() to segment the future
+            .boxed()
+            .await
+            .context("Failed to start remote execution")?;
 
         // Now we wait until the ExecuteResponse shows up, and produce events accordingly. If
         // this doesn't give us an ExecuteResponse then this is case #1 again so we also fail.
@@ -1922,12 +1874,6 @@ impl RemoteExecutionClientImpl {
                         return Ok(ChunkDownloadResult::Cancelled);
                     }
                 };
-
-                let _grpc_permit = self
-                    .grpc_semaphore
-                    .acquire()
-                    .await
-                    .expect("Semaphore should never be closed");
 
                 let response = with_error_handler(
                     "materialize_files",


### PR DESCRIPTION
Revert of https://github.com/MercuryTechnologies/buck2/commit/1db69332d13a4bc08c6d7b2a9448f85f482a8b77.

Now that we use connection pooling, this is artificially limiting concurrency to 400 and hurting performance. We never actually verified that this (in isolation) was solving any issues.