### PR TITLE
Keep the inplace pex bootstrapper relocatable

### DIFF
--- a/prelude/python/tools/BUCK
+++ b/prelude/python/tools/BUCK
@@ -120,11 +120,13 @@ prelude.python_bootstrap_binary(
 )
 
 # Run the test suite with this command:
-# buck2 run prelude//python/tools:wheel_tests --target-platforms prelude//platforms:default
+# buck2 run prelude//python/tools:tool_tests --target-platforms prelude//platforms:default
 prelude.sh_binary(
-    name = "wheel_tests",
+    name = "tool_tests",
     main = "tests/main.sh",
     resources = [
+        "make_py_package_inplace.py",
+        "run_inplace.py.in",
         "wheel.py",
     ]
     + glob(["tests/**/*.py"]),

--- a/prelude/python/tools/make_py_package_inplace.py
+++ b/prelude/python/tools/make_py_package_inplace.py
@@ -43,6 +43,34 @@ import platform
 import stat
 from pathlib import Path
 
+# Substituted for `<PYTHON>` in the template, i.e. it is what follows the `#!`.
+#
+# A shell/Python polyglot: `/bin/sh` runs the lines between `"true" '''` and the
+# closing `'''`, while Python parses the same text as two implicitly concatenated
+# string literals and keeps it as the module docstring. Windows has no `#!` support
+# and invokes the bootstrapper as `python <pex>`, where it is likewise inert.
+#
+# `<REL_PYTHON>` is the interpreter's path relative to the bootstrapper.
+_SH_TRAMPOLINE = r"""/bin/sh
+"true" '''\'
+# Resolve this script, following symlinks, so the interpreter can be found next to it.
+_self=$0
+case $_self in */*) ;; *) _self=./$_self ;; esac
+_hops=0
+while [ -L "$_self" ] && [ "$_hops" -lt 32 ]; do
+    # `readlink` is not a shell builtin and `$PATH` may be scrubbed. Without it the
+    # best we can do is assume the symlink sits alongside the interpreter.
+    _link=$(readlink "$_self" 2>/dev/null) || break
+    [ -n "$_link" ] || break
+    case $_link in
+        /*) _self=$_link ;;
+        *) _self=${_self%/*}/$_link ;;
+    esac
+    _hops=$((_hops + 1))
+done
+exec "${_self%/*}/<REL_PYTHON>" "$0" "$@"
+'''"""
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -69,7 +97,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--python",
         required=True,
-        help="The python binary to put in the bootstrapper hashbang",
+        help=(
+            "The python binary to launch the bootstrapper with. An absolute path or a"
+            " bare name goes straight into the hashbang; a project-root-relative path"
+            " is resolved at runtime against the bootstrapper, see launcher()"
+        ),
     )
     parser.add_argument(
         "--host-python",
@@ -144,6 +176,36 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def launcher(python: str, output_dir: Path) -> str:
+    """Build the body of the bootstrapper's `#!` line, i.e. how to start `python`.
+
+    The result must not depend on where the project root happens to sit on this
+    machine. The action's command line doesn't, so neither does its cache key, and an
+    output holding a local absolute path would poison the cache for every other reader.
+    """
+
+    separators = (os.path.sep, os.path.altsep)
+    if os.path.isabs(python) or not any(sep and sep in python for sep in separators):
+        # An absolute path is machine-independent already, and a bare word is for
+        # `/usr/bin/env` to look up on `$PATH`. Both work directly in a `#!` line.
+        #
+        # TODO(nmj): Remove this hack. So, if arg0 in your shebang is a bash script
+        #                 (like /usr/local/fbcode/platform007/bin/python3.7 on macs is)
+        #                 OSX just sort of ignores it and tries to run your thing with
+        #                 the current shell. So, we hack in /usr/bin/env in the front
+        #                 for now, and let it do the lifting. OSX: Bringing you the best
+        #                 of 1980s BSD in 2021...
+        return f"/usr/bin/env {python}"
+
+    # The interpreter is a build artifact, so buck2 handed us a path relative to the
+    # project root. A `#!` line can't carry one, because the kernel resolves it against
+    # the caller's cwd, so defer to a shell that resolves it against the bootstrapper.
+    relative_python = os.path.relpath(python, output_dir)
+    return _SH_TRAMPOLINE.replace(
+        "<REL_PYTHON>", relative_python.replace(os.path.sep, "/")
+    )
+
+
 def write_bootstrapper(args: argparse.Namespace) -> None:
     """Write the .pex bootstrapper script using a template"""
 
@@ -155,24 +217,14 @@ def write_bootstrapper(args: argparse.Namespace) -> None:
     relative_modules_dir = os.path.relpath(args.modules_dir, args.output.parent)
     native_lib_dirs = [relative_modules_dir] + args.native_library_runtime_paths
 
-    # TODO(nmj): Remove this hack. So, if arg0 in your shebang is a bash script
-    #                 (like /usr/local/fbcode/platform007/bin/python3.7 on macs is)
-    #                 OSX just sort of ignores it and tries to run your thing with
-    #                 the current shell. So, we hack in /usr/bin/env in the front
-    #                 for now, and let it do the lifting. OSX: Bringing you the best
-    #                 of 1980s BSD in 2021...
-
     ld_preload = None
     if args.preload_libraries:
         ld_preload = [p.name for p in args.preload_libraries]
 
-    python = str(args.python)
-    if not os.path.isabs(python) and os.path.sep in python:
-        python = os.path.abspath(python)
-
-    new_data = data.replace("<PYTHON>", f"/usr/bin/env {python}")
-    # Instead, pass interpreter flags via the Python variable that the re-exec
-    # path uses (e.g. -Xgil=0 for free-threaded builds).
+    new_data = data.replace("<PYTHON>", launcher(str(args.python), args.output.parent))
+    # Interpreter flags go to the Python variable that the re-exec path reads (e.g.
+    # -Xgil=0 for free-threaded builds) rather than onto the `#!` line, which on Linux
+    # can carry at most one argument.
     new_data = new_data.replace(
         "<PYTHON_INTERPRETER_FLAGS>", " ".join(args.python_interpreter_flags or [])
     )

--- a/prelude/python/tools/run_inplace.py.in
+++ b/prelude/python/tools/run_inplace.py.in
@@ -6,6 +6,9 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+# N.B. When the interpreter is a build artifact, the `#!` line above expands to several
+# lines of shell/Python polyglot that resolve it relative to this file.
+
 # LINKTREEDIR=<MODULES_DIR>
 
 main_module = "<MAIN_MODULE>"

--- a/prelude/python/tools/tests/make_py_package_inplace_test.py
+++ b/prelude/python/tools/tests/make_py_package_inplace_test.py
@@ -1,0 +1,218 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# pyre-strict
+
+import contextlib
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Iterator, Sequence
+
+import make_py_package_inplace
+
+TEMPLATE: Path = Path(__file__).resolve().parent.parent / "run_inplace.py.in"
+
+# An interpreter that some other rule built, as buck2 spells it: relative to the
+# project root, which is also the cwd the action runs in.
+ARTIFACT_PYTHON = "buck-out/v2/gen/toolchains/cpython/bin/python3"
+
+STUB_RUNNER = """\
+def run_as_main(main_module, main_function):
+    import runpy
+
+    runpy.run_module(main_module, run_name="__main__", alter_sys=True)
+"""
+
+APP = """\
+import os
+
+print("ran with PYTHONPATH", os.environ["PYTHONPATH"])
+"""
+
+
+@contextlib.contextmanager
+def _cwd(path: Path) -> Iterator[None]:
+    old = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+
+def _make_bootstrapper(
+    project_root: Path,
+    python: str,
+    output: str = "out/bin.pex",
+    modules_dir: str = "out/bin#link-tree",
+) -> Path:
+    """Invoke the tool the way buck2 does: from the project root, with relative paths."""
+
+    argv = [
+        "make_py_package_inplace.py",
+        "--template",
+        str(TEMPLATE),
+        "--python",
+        python,
+        "--host-python",
+        sys.executable,
+        "--entry-point",
+        "app",
+        "--main-runner",
+        "stub_runner.run_as_main",
+        "--modules-dir",
+        modules_dir,
+        output,
+    ]
+
+    old_argv = sys.argv
+    sys.argv = argv
+    try:
+        with _cwd(project_root):
+            make_py_package_inplace.main()
+    finally:
+        sys.argv = old_argv
+    return project_root / output
+
+
+class ShebangTest(unittest.TestCase):
+    def test_bare_interpreter_is_left_to_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = _make_bootstrapper(Path(tmpdir), "python3")
+            self.assertEqual(
+                pex.read_text(encoding="utf8").splitlines()[0],
+                "#!/usr/bin/env python3",
+            )
+
+    def test_absolute_interpreter_is_used_verbatim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = _make_bootstrapper(Path(tmpdir), "/usr/bin/python3")
+            self.assertEqual(
+                pex.read_text(encoding="utf8").splitlines()[0],
+                "#!/usr/bin/env /usr/bin/python3",
+            )
+
+    def test_artifact_interpreter_uses_sh_trampoline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = _make_bootstrapper(Path(tmpdir), ARTIFACT_PYTHON)
+            lines = pex.read_text(encoding="utf8").splitlines()
+
+            self.assertEqual(lines[0], "#!/bin/sh")
+            self.assertIn(
+                'exec "${_self%/*}/../buck-out/v2/gen/toolchains/cpython/bin/python3"'
+                ' "$0" "$@"',
+                lines,
+            )
+
+    def test_output_holds_no_absolute_path(self) -> None:
+        # The whole point: an absolute path here is this machine's, and gets shipped to
+        # everyone else that reads the action out of the cache.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = _make_bootstrapper(Path(tmpdir), ARTIFACT_PYTHON)
+            self.assertNotIn(tmpdir, pex.read_text(encoding="utf8"))
+
+    def test_output_does_not_depend_on_project_root(self) -> None:
+        outputs = []
+        for name in ("short", "a/much/deeper/checkout/path"):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir) / name
+                root.mkdir(parents=True)
+                outputs.append(_make_bootstrapper(root, ARTIFACT_PYTHON).read_bytes())
+        self.assertEqual(outputs[0], outputs[1])
+
+    def test_bootstrapper_is_valid_python(self) -> None:
+        # Windows ignores `#!` and runs the bootstrapper as `python <pex>`, so the shell
+        # trampoline has to parse as Python too.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = _make_bootstrapper(Path(tmpdir), ARTIFACT_PYTHON)
+            compile(pex.read_text(encoding="utf8"), str(pex), "exec")
+
+
+@unittest.skipIf(sys.platform == "win32", "no #! support on Windows")
+class TrampolineRuntimeTest(unittest.TestCase):
+    def _make_project(self, tmpdir: str, name: str = "project") -> Path:
+        root = Path(tmpdir) / name
+        (root / "out/bin#link-tree").mkdir(parents=True)
+        (root / "out/bin#link-tree/stub_runner.py").write_text(
+            STUB_RUNNER, encoding="utf8"
+        )
+        (root / "out/bin#link-tree/app.py").write_text(APP, encoding="utf8")
+
+        # Stand in for a hermetic interpreter built by some other rule.
+        (root / "buck-out/interpreter").mkdir(parents=True)
+        os.symlink(
+            os.path.realpath(sys.executable), root / "buck-out/interpreter/python3"
+        )
+
+        _make_bootstrapper(root, "buck-out/interpreter/python3")
+        return root
+
+    def _run(self, argv: Sequence[str], cwd: str) -> str:
+        proc = subprocess.run(
+            list(argv),
+            cwd=cwd,
+            capture_output=True,
+            encoding="utf8",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        return proc.stdout
+
+    def test_runs_from_an_unrelated_cwd(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_project(tmpdir)
+            out = self._run([str(root / "out/bin.pex")], cwd=tempfile.gettempdir())
+            self.assertIn(
+                "ran with PYTHONPATH {}".format(root / "out/bin#link-tree"), out
+            )
+
+    def test_runs_with_a_relative_argv0(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_project(tmpdir)
+            out = self._run(["./out/bin.pex"], cwd=str(root))
+            self.assertIn(
+                "ran with PYTHONPATH {}".format(root / "out/bin#link-tree"), out
+            )
+
+    def test_runs_from_a_path_with_spaces(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_project(tmpdir, name="a project")
+            out = self._run([str(root / "out/bin.pex")], cwd=tempfile.gettempdir())
+            self.assertIn(
+                "ran with PYTHONPATH {}".format(root / "out/bin#link-tree"), out
+            )
+
+    def test_runs_through_a_chain_of_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_project(tmpdir)
+            # A relative link, then an absolute one pointing at it.
+            os.symlink("out/bin.pex", root / "relative-link.pex")
+            os.symlink(root / "relative-link.pex", Path(tmpdir) / "absolute-link.pex")
+            out = self._run(
+                [str(Path(tmpdir) / "absolute-link.pex")], cwd=tempfile.gettempdir()
+            )
+            self.assertIn(
+                "ran with PYTHONPATH {}".format(root / "out/bin#link-tree"), out
+            )
+
+    def test_runs_without_a_usable_path(self) -> None:
+        # Pexes get used as build tools, where buck2 scrubs the environment. Nothing in
+        # the trampoline may depend on finding a helper on $PATH.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = self._make_project(tmpdir) / "out/bin.pex"
+            proc = subprocess.run(
+                [str(pex)],
+                env={},
+                capture_output=True,
+                encoding="utf8",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("ran with PYTHONPATH", proc.stdout)


### PR DESCRIPTION
this is a cherry-pick from buck2 main. i don't want to deal with rebasing to get it but you can drop this the moment that we rebase next.

Summary:
`make_py_package_inplace.py` absolutizes the interpreter path before putting it in the bootstrapper's `#!` line. When the interpreter is a build artifact, buck2 hands us a project-root-relative path, so the output ends up holding whatever absolute path the *builder* had. The action's command line doesn't contain that path, so its cache key doesn't either: the artifact is not a function of its inputs, and anyone reading it back out of the cache gets a pex pointing at a directory that doesn't exist for them.

Absolute and bare-word interpreters are untouched. For the artifact case the shebang becomes a `#!/bin/sh` trampoline that resolves the interpreter against the bootstrapper's own location, which is both relocatable and independent of cwd. It is a shell/Python polyglot so that Windows, which ignores `#!` and runs the bootstrapper as `python <pex>`, still parses the file.

Upstream reports: https://github.com/facebook/buck2/issues/1135 and https://github.com/facebook/buck2/issues/1268. Inspired by https://github.com/facebook/buck2/pull/1444 - this is a reworked version of that PR's first half (without the cache upload fix)

Reviewed By: 8Keep

Differential Revision: D114911001

fbshipit-source-id: fc20faf1729bf69618697a838bb8caffee9e0192