### PR TITLE
DUX-5667 Honor `buck2.infer_target_names` in queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ dependencies = [
  "buck2_fs",
  "buck2_hash",
  "buck2_interpreter",
+ "buck2_interpreter_for_build",
  "buck2_node",
  "buck2_query",
  "buck2_query_parser",

--- a/app/buck2_core/src/pattern/pattern.rs
+++ b/app/buck2_core/src/pattern/pattern.rs
@@ -522,12 +522,29 @@ impl<T: PatternType> ParsedPatternWithModifiers<T> {
         cell_resolver: &CellResolver,
         cell_alias_resolver: &CellAliasResolver,
     ) -> buck2_error::Result<Self> {
+        Self::parse_not_relaxed_with_inference(
+            pattern,
+            relative,
+            cell_resolver,
+            cell_alias_resolver,
+            InferTargetNames::No,
+        )
+    }
+
+    /// Like [`Self::parse_not_relaxed`], but optionally infers an eponymous target name.
+    pub fn parse_not_relaxed_with_inference(
+        pattern: &str,
+        relative: TargetParsingRel<'_>,
+        cell_resolver: &CellResolver,
+        cell_alias_resolver: &CellAliasResolver,
+        infer_target: InferTargetNames,
+    ) -> buck2_error::Result<Self> {
         parse_target_pattern(
             cell_resolver,
             cell_alias_resolver,
             TargetParsingOptions {
                 relative,
-                infer_target: InferTargetNames::No,
+                infer_target,
                 strip_package_trailing_slash: false,
             },
             pattern,

--- a/app/buck2_interpreter_for_build/src/interpreter/configuror.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/configuror.rs
@@ -109,7 +109,7 @@ impl BuildInterpreterConfiguror {
         }))
     }
 
-    pub(crate) fn infer_target_names(&self) -> InferTargetNames {
+    pub fn infer_target_names(&self) -> InferTargetNames {
         self.infer_target_names
     }
 

--- a/app/buck2_query_impls/BUCK
+++ b/app/buck2_query_impls/BUCK
@@ -30,6 +30,7 @@ rust_library(
         "//buck2/app/buck2_fs:buck2_fs",
         "//buck2/app/buck2_hash:buck2_hash",
         "//buck2/app/buck2_interpreter:buck2_interpreter",
+        "//buck2/app/buck2_interpreter_for_build:buck2_interpreter_for_build",
         "//buck2/app/buck2_node:buck2_node",
         "//buck2/app/buck2_query:buck2_query",
         "//buck2/app/buck2_query_parser:buck2_query_parser",

--- a/app/buck2_query_impls/Cargo.toml
+++ b/app/buck2_query_impls/Cargo.toml
@@ -19,6 +19,7 @@ buck2_events.workspace = true
 buck2_fs.workspace = true
 buck2_hash.workspace = true
 buck2_interpreter.workspace = true
+buck2_interpreter_for_build.workspace = true
 buck2_node.workspace = true
 buck2_query.workspace = true
 buck2_query_parser.workspace = true

--- a/app/buck2_query_impls/src/aquery/bxl.rs
+++ b/app/buck2_query_impls/src/aquery/bxl.rs
@@ -25,6 +25,7 @@ use buck2_core::fs::project_rel_path::ProjectRelativePathBuf;
 use buck2_core::global_cfg_options::GlobalCfgOptions;
 use buck2_core::provider::label::ConfiguredProvidersLabel;
 use buck2_core::target::configured_target_label::ConfiguredTargetLabel;
+use buck2_interpreter_for_build::interpreter::context::HasInterpreterContext;
 use buck2_query::query::syntax::simple::eval::file_set::FileSet;
 use buck2_query::query::syntax::simple::eval::set::TargetSet;
 use buck2_query::query::syntax::simple::eval::values::QueryValue;
@@ -71,6 +72,11 @@ impl BxlAqueryFunctionsImpl {
             .await?;
 
         let target_alias_resolver = dice.get().target_alias_resolver().await?.dupe();
+        let infer_target_names = dice
+            .get()
+            .get_interpreter_configuror()
+            .await?
+            .infer_target_names();
 
         let query_data = Arc::new(DiceQueryData::new(
             self.global_cfg_options.dupe(),
@@ -79,6 +85,7 @@ impl BxlAqueryFunctionsImpl {
             &self.working_dir,
             self.project_root.dupe(),
             target_alias_resolver,
+            infer_target_names,
             false, // allow_partial_graph
         ));
         let query_delegate = DiceQueryDelegate::new(dice, query_data);

--- a/app/buck2_query_impls/src/cquery/bxl.rs
+++ b/app/buck2_query_impls/src/cquery/bxl.rs
@@ -19,6 +19,7 @@ use buck2_core::configuration::compatibility::MaybeCompatible;
 use buck2_core::fs::project::ProjectRoot;
 use buck2_core::fs::project_rel_path::ProjectRelativePathBuf;
 use buck2_core::global_cfg_options::GlobalCfgOptions;
+use buck2_interpreter_for_build::interpreter::context::HasInterpreterContext;
 use buck2_node::configured_universe::CqueryUniverse;
 use buck2_node::nodes::configured::ConfiguredTargetNode;
 use buck2_query::query::syntax::simple::eval::file_set::FileSet;
@@ -59,6 +60,11 @@ impl BxlCqueryFunctionsImpl {
             .dupe();
 
         let target_alias_resolver = dice.get().target_alias_resolver().await?.dupe();
+        let infer_target_names = dice
+            .get()
+            .get_interpreter_configuror()
+            .await?
+            .infer_target_names();
 
         let query_data = Arc::new(DiceQueryData::new(
             self.global_cfg_options.dupe(),
@@ -67,6 +73,7 @@ impl BxlCqueryFunctionsImpl {
             &self.working_dir,
             self.project_root.dupe(),
             target_alias_resolver,
+            infer_target_names,
             false, // allow_partial_graph
         ));
 

--- a/app/buck2_query_impls/src/dice.rs
+++ b/app/buck2_query_impls/src/dice.rs
@@ -47,6 +47,7 @@ use buck2_fs::paths::abs_norm_path::AbsNormPathBuf;
 use buck2_fs::paths::file_name::FileNameBuf;
 use buck2_hash::BuckMutMap;
 use buck2_hash::buck_indexset;
+use buck2_interpreter_for_build::interpreter::context::HasInterpreterContext;
 use buck2_node::load_patterns::MissingTargetBehavior;
 use buck2_node::load_patterns::load_patterns;
 use buck2_node::nodes::configured::ConfiguredTargetNode;
@@ -82,6 +83,7 @@ pub(crate) struct LiteralParser {
     cell_resolver: CellResolver,
     cell_alias_resolver: CellAliasResolver,
     target_alias_resolver: BuckConfigTargetAliasResolver,
+    infer_target_names: InferTargetNames,
 }
 
 impl LiteralParser {
@@ -153,7 +155,7 @@ impl LiteralParser {
             ),
             &self.cell_resolver,
             &self.cell_alias_resolver,
-            InferTargetNames::No,
+            self.infer_target_names,
         )
     }
 
@@ -161,7 +163,7 @@ impl LiteralParser {
         &self,
         value: &str,
     ) -> buck2_error::Result<ParsedPatternWithModifiers<ProvidersPatternExtra>> {
-        ParsedPatternWithModifiers::parse_not_relaxed(
+        ParsedPatternWithModifiers::parse_not_relaxed_with_inference(
             value,
             TargetParsingRel::AllowRelative(
                 &CellPathWithAllowedRelativeDir::backwards_relative_not_supported(
@@ -171,6 +173,7 @@ impl LiteralParser {
             ),
             &self.cell_resolver,
             &self.cell_alias_resolver,
+            self.infer_target_names,
         )
     }
 
@@ -209,6 +212,7 @@ impl DiceQueryData {
         working_dir: &ProjectRelativePath,
         project_root: ProjectRoot,
         target_alias_resolver: BuckConfigTargetAliasResolver,
+        infer_target_names: InferTargetNames,
         allow_partial_graph: bool,
     ) -> Self {
         let cell_path = cell_resolver.get_cell_path(working_dir);
@@ -223,6 +227,7 @@ impl DiceQueryData {
                 cell_resolver,
                 cell_alias_resolver,
                 target_alias_resolver,
+                infer_target_names,
             },
             global_cfg_options,
             allow_partial_graph,
@@ -428,6 +433,11 @@ pub(crate) async fn get_dice_query_delegate<'a, 'c: 'a, 'd>(
         .await?
         .dupe();
     let target_alias_resolver = ctx.get().target_alias_resolver().await?.dupe();
+    let infer_target_names = ctx
+        .get()
+        .get_interpreter_configuror()
+        .await?
+        .infer_target_names();
     let project_root = ctx
         .get()
         .global_data()
@@ -443,6 +453,7 @@ pub(crate) async fn get_dice_query_delegate<'a, 'c: 'a, 'd>(
             working_dir,
             project_root,
             target_alias_resolver,
+            infer_target_names,
             allow_partial_graph,
         )),
     ))

--- a/app/buck2_query_impls/src/uquery/bxl.rs
+++ b/app/buck2_query_impls/src/uquery/bxl.rs
@@ -18,6 +18,7 @@ use buck2_common::target_aliases::HasTargetAliasResolver;
 use buck2_core::fs::project::ProjectRoot;
 use buck2_core::fs::project_rel_path::ProjectRelativePathBuf;
 use buck2_core::global_cfg_options::GlobalCfgOptions;
+use buck2_interpreter_for_build::interpreter::context::HasInterpreterContext;
 use buck2_node::nodes::unconfigured::TargetNode;
 use buck2_query::query::syntax::simple::eval::file_set::FileSet;
 use buck2_query::query::syntax::simple::eval::set::TargetSet;
@@ -55,6 +56,11 @@ impl BxlUqueryFunctionsImpl {
             .await?
             .dupe();
         let target_alias_resolver = dice.get().target_alias_resolver().await?.dupe();
+        let infer_target_names = dice
+            .get()
+            .get_interpreter_configuror()
+            .await?
+            .infer_target_names();
 
         let query_data = Arc::new(DiceQueryData::new(
             GlobalCfgOptions::default(),
@@ -63,6 +69,7 @@ impl BxlUqueryFunctionsImpl {
             &self.working_dir,
             self.project_root.dupe(),
             target_alias_resolver,
+            infer_target_names,
             false, // allow_partial_graph
         ));
         Ok(DiceQueryDelegate::new(dice, query_data))

--- a/app/buck2_server/src/lsp.rs
+++ b/app/buck2_server/src/lsp.rs
@@ -17,8 +17,6 @@ use buck2_build_api::actions::artifact::get_artifact_fs::GetArtifactFs;
 use buck2_cli_proto::*;
 use buck2_common::dice::cells::HasCellResolver;
 use buck2_common::file_ops::dice::DiceFileComputations;
-use buck2_common::legacy_configs::dice::HasLegacyConfigs;
-use buck2_common::legacy_configs::key::BuckconfigKeyRef;
 use buck2_common::package_listing::dice::DicePackageListingResolver;
 use buck2_core::bxl::BxlFilePath;
 use buck2_core::bzl::ImportPath;
@@ -29,7 +27,6 @@ use buck2_core::fs::project::ProjectRoot;
 use buck2_core::fs::project_rel_path::ProjectRelativePath;
 use buck2_core::package::package_relative_path::PackageRelativePath;
 use buck2_core::package::source_path::SourcePath;
-use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::pattern::pattern::ParsedPattern;
 use buck2_core::pattern::pattern::TargetParsingRel;
 use buck2_core::pattern::pattern_type::ProvidersPatternExtra;
@@ -48,6 +45,7 @@ use buck2_interpreter::load_module::InterpreterCalculation;
 use buck2_interpreter::paths::module::OwnedStarlarkModulePath;
 use buck2_interpreter::paths::path::OwnedStarlarkPath;
 use buck2_interpreter::prelude_path::prelude_path;
+use buck2_interpreter_for_build::interpreter::context::HasInterpreterContext;
 use buck2_interpreter_for_build::interpreter::dice_calculation_delegate::HasCalculationDelegate;
 use buck2_interpreter_for_build::interpreter::global_interpreter_state::HasGlobalInterpreterState;
 use buck2_interpreter_for_build::interpreter::interpreter_for_dir::ParseData;
@@ -514,22 +512,11 @@ impl<'a> BuckLspContext<'a> {
     ) -> buck2_error::Result<Option<StringLiteralResult>> {
         self.with_dice_ctx(|dice_ctx| async move {
             let artifact_fs = dice_ctx.ctx().get_artifact_fs().await?;
-            let infer_target_names = if dice_ctx
+            let infer_target_names = dice_ctx
                 .ctx()
-                .parse_legacy_config_property(
-                    artifact_fs.cell_resolver().root_cell(),
-                    BuckconfigKeyRef {
-                        section: "buck2",
-                        property: "infer_target_names",
-                    },
-                )
+                .get_interpreter_configuror()
                 .await?
-                .unwrap_or(false)
-            {
-                InferTargetNames::Yes
-            } else {
-                InferTargetNames::No
-            };
+                .infer_target_names();
             let (cell_alias_resolver, dir_with_allowed_relative_dirs) = (
                 dice_ctx
                     .ctx()

--- a/tests/core/interpreter/test_infer_target_names.py
+++ b/tests/core/interpreter/test_infer_target_names.py
@@ -41,6 +41,20 @@ async def test_eponymous_dep_in_build_file_inferred_when_enabled(buck: Buck) -> 
 
 
 @buck_test()
+async def test_eponymous_query_literal_inferred_when_enabled(buck: Buck) -> None:
+    # Query literals use a separate parser from attributes in build files. It must
+    # honor the same setting so tools can feed abbreviated labels back to Buck.
+    res = await buck.uquery("deps(root//lib/greeting)", "-c", _ENABLE)
+    assert "root//lib/greeting:greeting" in res.stdout
+
+
+@buck_test()
+async def test_bxl_query_filter_infers_target_name_when_enabled(buck: Buck) -> None:
+    res = await buck.bxl("//:infer_target_names.bxl:main", "-c", _ENABLE)
+    assert res.stdout.strip() == "[root//foo:foo]"
+
+
+@buck_test()
 async def test_eponymous_source_in_build_file_rejected_by_default(buck: Buck) -> None:
     # `attrs.source()` takes either a path or a label, so it coerces separately
     # from `attrs.dep()`. Without the buckconfig, `//lib/greeting` fails as both

--- a/tests/core/interpreter/test_infer_target_names_data/foo/TARGETS.fixture
+++ b/tests/core/interpreter/test_infer_target_names_data/foo/TARGETS.fixture
@@ -1,0 +1,3 @@
+load("//:defs.bzl", "simple")
+
+simple(name = "foo")

--- a/tests/core/interpreter/test_infer_target_names_data/infer_target_names.bxl
+++ b/tests/core/interpreter/test_infer_target_names_data/infer_target_names.bxl
@@ -1,0 +1,8 @@
+def _impl(ctx):
+    result = ctx.uquery().deps("//foo:foo", filter = "//foo")
+    ctx.output.print(result)
+
+main = bxl_main(
+    impl = _impl,
+    cli_args = {},
+)


### PR DESCRIPTION
Honor the `buck2.infer_target_names` setting in uquery, cquery, aquery, and BXL query evaluation. Thread `InferTargetNames` through the shared query literal parser.

NB: This may be a bug aside from the setting; `buck build` and most other commands already interpret `//foo` as `//foo:foo`, so it's a bit odd that `buck uquery` and similar wouldn't.

See 088c75c7e36805df99c3de29062baa95db700b8b (https://github.com/facebook/buck2/pull/1004 Differential Revision D112694484).

Upstream: https://github.com/facebook/buck2/pull/1467