### PR TITLE
test env: include LOCALE_ARCHIVE

### DIFF
--- a/app/buck2_execute/src/execute/environment_inheritance.rs
+++ b/app/buck2_execute/src/execute/environment_inheritance.rs
@@ -25,6 +25,8 @@ const ENV_ALLOW_LIST: &[&str] = &[
     "TMPDIR",
     // Generally needed to keep systemd working
     "XDG_RUNTIME_DIR",
+    // Nix glibc locale archive
+    "LOCALE_ARCHIVE",
 ];
 
 // The standard (built-in) variables.


### PR DESCRIPTION
The reason we need this is that nix doesn't hardcode the location of the
glibc locales and use it as an impure dependency. Which thus means that
we need to be able to wrap it into our buck2 itself, so that we have
fully hermetic glibc locales on Linux.

The upshot of this is that we need to add it to the list of env vars
that go into tests.

Upstream PR: https://github.com/facebook/buck2/pull/1468