### PR TITLE
DUX-5651: set up LC_CTYPE to a safe default value x-platform

### DIFF
--- a/app/buck2_test/src/internal_runner.rs
+++ b/app/buck2_test/src/internal_runner.rs
@@ -30,6 +30,8 @@ use buck2_test_api::data::RequiredLocalResources;
 use buck2_test_api::data::TestResult;
 use buck2_test_api::data::TestStage;
 use buck2_test_api::data::TestStatus;
+use buck2_test_api::environment::TestEnvironment;
+use buck2_test_api::environment::build_test_env;
 use buck2_test_api::protocol::TestOrchestrator;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
@@ -300,21 +302,13 @@ fn build_command_from_spec(spec: &ExternalRunnerSpec) -> Vec<ArgValue> {
         .collect()
 }
 
-fn build_env_from_spec(
-    spec: &ExternalRunnerSpec,
-) -> sorted_vector_map::SortedVectorMap<String, ArgValue> {
-    spec.env
-        .iter()
-        .map(|(k, v)| {
-            (
-                k.clone(),
-                ArgValue {
-                    content: ArgValueContent::ExternalRunnerSpecValue(v.clone()),
-                    format: None,
-                },
-            )
-        })
-        .collect()
+fn build_env_from_spec(spec: &ExternalRunnerSpec) -> TestEnvironment {
+    build_test_env(
+        spec.env
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone())),
+        std::env::var_os("LC_CTYPE").map(|value| value.to_string_lossy().into_owned()),
+    )
 }
 
 fn format_execution_output(stdout: &ExecutionStream, stderr: &ExecutionStream) -> String {
@@ -400,7 +394,6 @@ mod tests {
     fn test_build_env_from_spec() {
         let spec = make_spec(vec![], vec![("FOO", "bar"), ("BAZ", "qux")]);
         let env = build_env_from_spec(&spec);
-        assert_eq!(env.len(), 2);
         assert!(env.contains_key("BAZ"));
         assert!(env.contains_key("FOO"));
     }

--- a/app/buck2_test_api/src/environment.rs
+++ b/app/buck2_test_api/src/environment.rs
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is dual-licensed under either the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree or the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree. You may select, at your option, one of the
+ * above-listed licenses.
+ */
+
+use sorted_vector_map::SortedVectorMap;
+
+use crate::data::ArgValue;
+use crate::data::ArgValueContent;
+use crate::data::ExternalRunnerSpecValue;
+
+pub type TestEnvironment = SortedVectorMap<String, ArgValue>;
+
+/// Build a test environment and add a UTF-8 `LC_CTYPE` when it is not already defined.
+/// We select `C.UTF-8` on Unices because it has deterministic behaviour and widely available.
+/// macOS and Windows get `en_US.UTF-8` because `C.UTF-8` is not available.
+/// In practice, this means that iconv related functions in libc will not corrupt or error out on
+/// UTF-8 text.
+///
+/// The caller supplies the test runner's process value so precedence can be tested without
+/// mutating the process environment. Test-runner CLI overrides, if any, should be applied after
+/// this function returns.
+pub fn build_test_env(
+    spec_env: impl IntoIterator<Item = (String, ExternalRunnerSpecValue)>,
+    process_lc_ctype: Option<String>,
+) -> TestEnvironment {
+    let mut env = spec_env
+        .into_iter()
+        .map(|(key, value)| {
+            (
+                key,
+                ArgValue {
+                    content: ArgValueContent::ExternalRunnerSpecValue(value),
+                    format: None,
+                },
+            )
+        })
+        .collect::<TestEnvironment>();
+
+    if env.contains_key("LC_CTYPE") {
+        return env;
+    }
+
+    let lc_ctype = process_lc_ctype.or_else(|| default_lc_ctype().map(str::to_owned));
+    if let Some(lc_ctype) = lc_ctype {
+        env.insert(
+            "LC_CTYPE".to_owned(),
+            ArgValue {
+                content: ArgValueContent::ExternalRunnerSpecValue(
+                    ExternalRunnerSpecValue::Verbatim(lc_ctype),
+                ),
+                format: None,
+            },
+        );
+    }
+
+    env
+}
+
+#[cfg(target_os = "macos")]
+fn default_lc_ctype() -> Option<&'static str> {
+    Some("en_US.UTF-8")
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn default_lc_ctype() -> Option<&'static str> {
+    Some("C.UTF-8")
+}
+
+#[cfg(windows)]
+fn default_lc_ctype() -> Option<&'static str> {
+    // This form is accepted by the UCRT and by Unix-like compatibility runtimes on Windows.
+    Some("en_US.UTF-8")
+}
+
+#[cfg(not(any(unix, windows)))]
+fn default_lc_ctype() -> Option<&'static str> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lc_ctype(env: &SortedVectorMap<String, ArgValue>) -> Option<&str> {
+        match env.get("LC_CTYPE").map(|value| &value.content) {
+            Some(ArgValueContent::ExternalRunnerSpecValue(ExternalRunnerSpecValue::Verbatim(
+                value,
+            ))) => Some(value),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn test_existing_value_wins_over_process() {
+        let env = build_test_env(
+            vec![(
+                "LC_CTYPE".to_owned(),
+                ExternalRunnerSpecValue::Verbatim("from-test".to_owned()),
+            )],
+            Some("from-process".to_owned()),
+        );
+        assert_eq!(lc_ctype(&env), Some("from-test"));
+    }
+
+    #[test]
+    fn test_process_value_wins_over_default() {
+        let env = build_test_env(vec![], Some("from-process".to_owned()));
+        assert_eq!(lc_ctype(&env), Some("from-process"));
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn test_platform_default() {
+        let env = build_test_env(vec![], None);
+        let expected = if cfg!(all(unix, not(target_os = "macos"))) {
+            "C.UTF-8"
+        } else {
+            "en_US.UTF-8"
+        };
+        assert_eq!(lc_ctype(&env), Some(expected));
+    }
+}

--- a/app/buck2_test_api/src/lib.rs
+++ b/app/buck2_test_api/src/lib.rs
@@ -25,5 +25,6 @@
 
 pub mod convert;
 pub mod data;
+pub mod environment;
 pub mod grpc;
 pub mod protocol;

--- a/app/buck2_test_runner/src/runner.rs
+++ b/app/buck2_test_runner/src/runner.rs
@@ -24,6 +24,8 @@ use buck2_test_api::data::RequiredLocalResources;
 use buck2_test_api::data::TestResult;
 use buck2_test_api::data::TestStage;
 use buck2_test_api::data::TestStatus;
+use buck2_test_api::environment::TestEnvironment;
+use buck2_test_api::environment::build_test_env;
 use buck2_test_api::grpc::TestOrchestratorClient;
 use clap::Parser;
 use futures::StreamExt;
@@ -155,32 +157,11 @@ impl Buck2TestRunner {
             .iter()
             .map(|s| s.parse())
             .collect::<buck2_error::Result<_>>()?;
-        let config_env = config_env.iter().map(|EnvValue { name, value }| {
-            (
-                name.to_owned(),
-                ArgValue {
-                    content: ArgValueContent::ExternalRunnerSpecValue(
-                        ExternalRunnerSpecValue::Verbatim(value.to_owned()),
-                    ),
-                    format: None,
-                },
-            )
-        });
-
-        let env = spec
-            .env
-            .into_iter()
-            .map(|(key, value)| {
-                (
-                    key,
-                    ArgValue {
-                        content: ArgValueContent::ExternalRunnerSpecValue(value),
-                        format: None,
-                    },
-                )
-            })
-            .chain(config_env)
-            .collect();
+        let env = build_env(
+            spec.env,
+            &config_env,
+            std::env::var_os("LC_CTYPE").map(|value| value.to_string_lossy().into_owned()),
+        );
 
         let target_handle = spec.target.handle;
         let host_sharing_requirements = HostSharingRequirements::default();
@@ -207,6 +188,28 @@ impl Buck2TestRunner {
         self.orchestrator_client
             .report_test_result(test_result)
             .await
+    }
+}
+
+fn build_env(
+    spec_env: impl IntoIterator<Item = (String, ExternalRunnerSpecValue)>,
+    config_env: &[EnvValue],
+    process_lc_ctype: Option<String>,
+) -> TestEnvironment {
+    let mut env = build_test_env(spec_env, process_lc_ctype);
+
+    // Test-executor `--env` values have highest precedence.
+    for EnvValue { name, value } in config_env {
+        env.insert(name.to_owned(), verbatim_env_value(value.to_owned()));
+    }
+
+    env
+}
+
+fn verbatim_env_value(value: String) -> ArgValue {
+    ArgValue {
+        content: ArgValueContent::ExternalRunnerSpecValue(ExternalRunnerSpecValue::Verbatim(value)),
+        format: None,
     }
 }
 
@@ -248,5 +251,33 @@ impl RunVerdict {
             RunVerdict::Pass => 0,
             RunVerdict::Fail => 32,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lc_ctype(env: &TestEnvironment) -> Option<&str> {
+        match env.get("LC_CTYPE").map(|value| &value.content) {
+            Some(ArgValueContent::ExternalRunnerSpecValue(ExternalRunnerSpecValue::Verbatim(
+                value,
+            ))) => Some(value),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn test_cli_env_overrides_base_environment() {
+        let config_env = vec![EnvValue::new("LC_CTYPE", "from-cli")];
+        let env = build_env(
+            vec![(
+                "LC_CTYPE".to_owned(),
+                ExternalRunnerSpecValue::Verbatim("from-test".to_owned()),
+            )],
+            &config_env,
+            Some("from-process".to_owned()),
+        );
+        assert_eq!(lc_ctype(&env), Some("from-cli"));
     }
 }


### PR DESCRIPTION
Problem:
Tests (including but not limited to Haskell) sometimes use the libc locales to interact with character sets; by default LANG=C and this causes corruption of UTF-8 text being passed through various libc text functions (it's real bad in Haskell where you can't print some UTF-8 to stdout without throwing an exception!). Buck2 eats those environment variables (including LANG), so that these tests are always broken.

I presume Meta defaults this to something deterministic in tpx somewhere.

Solution:
If buck2 is going to eat the env-vars, it's probably best that we make it have reasonable behaviour for those who haven't yet noticed being bitten by their programs running in the C locale.

Weakly default to C.UTF-8 for LC_CTYPE when running tests. Allow basically anything to override it: --env, invoker's environment, etc. We eat all other locale variables, which wind up defaulting to C (which is fine).

I checked with an agent that with C.UTF-8 and en_US.UTF-8 the transliteration to ascii is the same. Collation order is codepoint order with C.UTF-8 unlike en_US where it is more human-friendly.

Uncertainties:
I don't know if it's smart to take what the caller environment contains for LC_CTYPE. That decision could go either way, to be honest: buck is pretty aggressive on test confinement, but on the other hand, it's an explicit signal from the user.

Upstream PR: https://github.com/facebook/buck2/pull/1469